### PR TITLE
Host fonts locally

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,8 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@fontsource/lora": "^4.5.0",
+    "@fontsource/source-sans-pro": "^4.5.0",
     "@mdi/font": "5.9.55",
     "chart.js": "^3.6.0",
     "core-js": "^3.6.5",

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -1,4 +1,5 @@
-@import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&display=swap');
+@import "~@fontsource/lora/index.css";
+@import "~@fontsource/source-sans-pro/index.css";
 
 $lora: 'Lora', serif;
 $source-sans-pro: 'Source Sans Pro', sans-serif;


### PR DESCRIPTION
Use local fonts instead of Google's hosted version. This enables offline operation.