### PR TITLE
Fix websocket edge case

### DIFF
--- a/backend/internal/api/websocket.go
+++ b/backend/internal/api/websocket.go
@@ -90,6 +90,12 @@ func BroadcastWebsocketMessage(messageType string, data interface{}) {
 
 	// Send this message to all registered websockets
 	for e := wsClients.Front(); e != nil; e = e.Next() {
+		if e.Value == nil {
+			wsClients.Remove(e)
+			logrus.Warn("[server] removed nil websocket")
+			continue
+		}
+
 		c := e.Value.(*websocket.Conn)
 
 		if err := c.WriteJSON(msg); err != nil {


### PR DESCRIPTION
I ran into this randomly when I was working on the new configuration wizard. If a websocket is nil and a websocket message is broadcast, the server will crash. This is a sub-optimal outcome.