### PR TITLE
Node module integration

### DIFF
--- a/frontend/src/components/NodeModule.vue
+++ b/frontend/src/components/NodeModule.vue
@@ -15,18 +15,26 @@
         </p>
       </v-col>
       <v-col class="rhs" :align-items="center">
-        <div v-if="isConnected">
-          <h2 class="connected">
-            Connected
-            <v-icon class="icon"> mdi-wifi-check </v-icon>
-          </h2>
-        </div>
-        <div v-else>
-          <h2 class="disconnected">
-            Disconnected
-            <v-icon class="icon"> mdi-wifi-off </v-icon>
-          </h2>
-        </div>
+        <v-container v-if="isConnected">
+            <h2 class="connected">
+              <tooltip :text="meshInfo(announcement)">
+                <span>
+                  Connected
+                  <v-icon class="icon"> mdi-wifi-check </v-icon>
+                </span>
+              </tooltip>
+            </h2>
+        </v-container>
+        <v-container v-else>
+            <h2 class="disconnected">
+              <tooltip :text="meshInfo(announcement)">
+                <span>
+                  Disconnected
+                  <v-icon class="icon"> mdi-wifi-off </v-icon>
+                </span>
+              </tooltip>
+            </h2>
+        </v-container>
         <p class="secondary-text">
           Last pushed {{ timestamp }} seconds ago
           <v-icon class="icon" small> mdi-clock </v-icon>
@@ -39,10 +47,20 @@
 
 <script lang="ts">
 import Vue from "vue";
+import { GardenSystem, GardenSystemInfo } from "@/store/types";
+import Tooltip from "@/components/Tooltip.vue";
+
 
 export default Vue.extend({
   name: "NodeModule",
-  props: ["moduleName", "identifier", "isConnected", "timestamp"]
+  components: { Tooltip },
+  props: ["moduleName", "identifier", "isConnected", "timestamp", "announcement"],
+  methods: {
+    meshInfo(announcement: GardenSystemInfo): any {
+      const mesh = announcement.IsMesh;
+      return mesh ? "Mesh" : `MQTT (CH ${announcement.Channel})`;
+    },
+  }
 });
 </script>
 

--- a/frontend/src/components/NodeModule.vue
+++ b/frontend/src/components/NodeModule.vue
@@ -1,8 +1,8 @@
 <template>
-  <router-link :to="'/system/' + identifier" tag="v-card">
-  <v-card v-ripple flat class="rounded-0 card">
+  <router-link :to="'/system/' + identifier" custom v-slot="{ navigate }">
+  <v-card @click="navigate" @keypress.enter="navigate" v-ripple flat class="rounded-0 card">
     <v-row class="parent-row">
-      <v-col md="auto" :cols="auto">
+      <v-col md="auto" cols="auto">
         <v-icon class="node-icon"> mdi-leaf </v-icon>
       </v-col>
       <v-col>
@@ -14,7 +14,7 @@
           </router-link>
         </p>
       </v-col>
-      <v-col class="rhs" :align-items="center">
+      <v-col class="rhs" align-items="center">
         <v-container v-if="isConnected">
             <h2 class="connected">
               <tooltip :text="meshInfo(announcement)">

--- a/frontend/src/components/NodeModule.vue
+++ b/frontend/src/components/NodeModule.vue
@@ -74,6 +74,7 @@ p a {
 }
 .parent-row {
   padding: 0 2rem;
+  margin: 0;
 }
 .secondary-text {
   color: $white-4;

--- a/frontend/src/components/NodeModule.vue
+++ b/frontend/src/components/NodeModule.vue
@@ -1,4 +1,5 @@
 <template>
+  <router-link :to="'/system/' + identifier" tag="v-card">
   <v-card v-ripple flat class="rounded-0 card">
     <v-row class="parent-row">
       <v-col md="auto" :cols="auto">
@@ -33,6 +34,7 @@
       </v-col>
     </v-row>
   </v-card>
+  </router-link>
 </template>
 
 <script lang="ts">

--- a/frontend/src/views/Systems.vue
+++ b/frontend/src/views/Systems.vue
@@ -1,6 +1,15 @@
 <template>
   <v-container>
     <p>Systems:</p>
+    <v-container :v-for="system in systems"> // fix this 
+      <node-module
+          moduleName="Node Module"
+          :identifier="$store.state.systems[0].Identifier"
+          isConnected="true"
+          :timestamp="age($store.state.systems[0].UpdatedAt)"
+        />
+    </v-container>
+    <br/>
     <v-data-table :items="$store.state.systems" :headers="headers">
       <template v-slot:[`item.Identifier`]="{ item }">
         <router-link :to="`/system/${item.Identifier}`">
@@ -132,10 +141,13 @@ import { MutationPayload } from "vuex";
 
 import CommandDialog from "@/components/CommandDialog.vue";
 import Tooltip from "@/components/Tooltip.vue";
+import NodeModule from "@/components/NodeModule.vue";
 
 export default Vue.extend({
   name: "Systems",
-  components: { CommandDialog, Tooltip },
+  components: { CommandDialog, Tooltip, NodeModule },
+  // components: { CommandDialog },
+  // state
   data() {
     return {
       headers: [
@@ -173,6 +185,7 @@ export default Vue.extend({
       }
     };
   },
+  // actions
   methods: {
     load(): void {
       // Load all initial systems.
@@ -208,7 +221,7 @@ export default Vue.extend({
     age(lastSeen: string): string {
       let diff = Number(new Date()) - Number(new Date(lastSeen));
       diff = Number(diff) / 1000;
-      return `last seen ${diff.toFixed(0)} seconds ago`;
+      return `${diff.toFixed(0)}`;
     },
     isEmulator(system: GardenSystem): boolean {
       return system.Announcement.IsEmulator;

--- a/frontend/src/views/Systems.vue
+++ b/frontend/src/views/Systems.vue
@@ -5,7 +5,7 @@
       <node-module
           moduleName="Node Module"
           :identifier="sys.Identifier"
-          :isConnected="true"
+          :isConnected="isConnected(sys.UpdatedAt)"
           :timestamp="age(sys.UpdatedAt)"
           :announcement="sys.Announcement"
         />
@@ -181,7 +181,6 @@ export default Vue.extend({
 
       return `${reading.toFixed(2)} °${units}`;
     },
-
     sendCommand(id: string) {
       this.command.id = id;
       this.command.show = true;
@@ -196,6 +195,13 @@ export default Vue.extend({
           command: command
         })
       });
+    },
+    isConnected(lastSeen: string): boolean {
+      let diff = Number(new Date()) - Number(new Date(lastSeen));
+      if (diff > 14999) { // arbitrary number in ms
+        return false;
+      }
+      return true;
     }
   },
   created() {

--- a/frontend/src/views/Systems.vue
+++ b/frontend/src/views/Systems.vue
@@ -1,99 +1,17 @@
 <template>
   <v-container>
     <p>Systems:</p>
-    <v-container :v-for="system in systems"> // fix this 
+    <div class="module-list-container" v-for="sys in $store.state.systems" :key="sys.Identifier">
       <node-module
           moduleName="Node Module"
-          :identifier="$store.state.systems[0].Identifier"
-          isConnected="true"
-          :timestamp="age($store.state.systems[0].UpdatedAt)"
+          :identifier="sys.Identifier"
+          :isConnected="true"
+          :timestamp="age(sys.UpdatedAt)"
+          :announcement="sys.Announcement"
         />
-    </v-container>
+    </div>
+    
     <br/>
-    <v-data-table :items="$store.state.systems" :headers="headers">
-      <template v-slot:[`item.Identifier`]="{ item }">
-        <router-link :to="`/system/${item.Identifier}`">
-          <code>{{ item.Identifier }}</code>
-        </router-link>
-      </template>
-
-      <template v-slot:[`item.Connection`]="{ item }">
-        <div class="readingData">
-          <tooltip :text="meshInfo(item, 'tooltip')">
-            <v-icon>
-              {{ meshInfo(item, "icon") }}
-            </v-icon>
-          </tooltip>
-
-          <span v-if="showSystemTypes" style="margin-left: 1rem">
-            <tooltip text="Virtual">
-              <v-icon v-if="isEmulator(item)">mdi-progress-wrench</v-icon>
-            </tooltip>
-
-            <tooltip text="Physical">
-              <v-icon v-if="!isEmulator(item)">mdi-memory</v-icon>
-            </tooltip>
-          </span>
-        </div>
-      </template>
-
-      <template v-slot:[`item.LastReading`]="{ item }">
-        <div id="reading" v-if="dataValid(item.UpdatedAt)">
-          <tooltip
-            v-if="item.LastReading.Error"
-            text="Error retrieving sensor data"
-          >
-            <v-icon color="red">mdi-alert</v-icon>
-          </tooltip>
-
-          <div v-if="!item.LastReading.Error">
-            <div
-              class="readingData"
-              v-if="isReadingValid(item.LastReading.Temperature)"
-            >
-              <tooltip text="Temperature">
-                <v-icon>mdi-thermometer</v-icon>
-                <span>{{ temp(item.LastReading.Temperature) }}</span>
-              </tooltip>
-            </div>
-
-            <div
-              class="readingData"
-              v-if="isReadingValid(item.LastReading.Humidity)"
-            >
-              <tooltip text="Humidity">
-                <v-icon>mdi-water-percent</v-icon>
-                <span>{{ item.LastReading.Humidity.toFixed(2) }} %</span>
-              </tooltip>
-            </div>
-          </div>
-          <div class="readingData" v-else>
-            <span class="red--text">Error retrieving sensor data</span>
-          </div>
-        </div>
-        <div id="reading" v-else>
-          <v-icon>mdi-clock</v-icon>
-          <span>has not reported data yet</span>
-        </div>
-      </template>
-
-      <template v-slot:[`item.UpdatedAt`]="{ item }">
-        <div class="readingData">
-          <v-icon style="margin-right: 0.5rem">mdi-clock</v-icon>
-          <span>{{ age(item.UpdatedAt) }}</span>
-        </div>
-      </template>
-
-      <template v-slot:[`item.Filesystem`]="{ item }">
-        <span v-if="!isEmulator(item)">
-          <div class="readingData">
-            <v-icon>mdi-file-multiple</v-icon>
-            {{ fsInfo(item.Announcement) }}
-          </div>
-        </span>
-      </template>
-    </v-data-table>
-    <br />
 
     <span>Send command to:</span>
     <br />
@@ -140,12 +58,11 @@ import { GardenSystem, GardenSystemInfo } from "@/store/types";
 import { MutationPayload } from "vuex";
 
 import CommandDialog from "@/components/CommandDialog.vue";
-import Tooltip from "@/components/Tooltip.vue";
 import NodeModule from "@/components/NodeModule.vue";
 
 export default Vue.extend({
   name: "Systems",
-  components: { CommandDialog, Tooltip, NodeModule },
+  components: { CommandDialog, NodeModule },
   // components: { CommandDialog },
   // state
   data() {
@@ -298,6 +215,11 @@ export default Vue.extend({
 </script>
 
 <style scoped>
+.module-list-container {
+  overflow: hidden;
+  border-radius: 4px;
+}
+
 div#reading span {
   margin-left: 0.1rem;
   margin-right: 0.1rem;

--- a/frontend/src/views/Systems.vue
+++ b/frontend/src/views/Systems.vue
@@ -63,7 +63,6 @@ import NodeModule from "@/components/NodeModule.vue";
 export default Vue.extend({
   name: "Systems",
   components: { CommandDialog, NodeModule },
-  // components: { CommandDialog },
   // state
   data() {
     return {
@@ -138,7 +137,7 @@ export default Vue.extend({
     age(lastSeen: string): string {
       let diff = Number(new Date()) - Number(new Date(lastSeen));
       diff = Number(diff) / 1000;
-      return `${diff.toFixed(0)}`;
+      return diff.toFixed(0);
     },
     isEmulator(system: GardenSystem): boolean {
       return system.Announcement.IsEmulator;
@@ -198,10 +197,7 @@ export default Vue.extend({
     },
     isConnected(lastSeen: string): boolean {
       let diff = Number(new Date()) - Number(new Date(lastSeen));
-      if (diff > 14999) { // arbitrary number in ms
-        return false;
-      }
-      return true;
+      return diff < 70 * 1000;
     }
   },
   created() {


### PR DESCRIPTION
**(Ignore branch name, gonna make search functionality its own branch)**

This PR fully integrates the Node Module Component to the main page. New additions:

- NodeModule component now contains a tooltip on the connection status to indicate connection type
- Connection status is determined via `isConnected()`
- Container around NodeModules to add 4px border (cuz *aesthetics*)