### PR TITLE
Support running multiple emulators at once

### DIFF
--- a/backend/cmd/emulator/emulator.go
+++ b/backend/cmd/emulator/emulator.go
@@ -15,26 +15,35 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var id string = "1234567890AB"
-var baseTopic string = "garden/module/" + id
+var id string
+var baseTopic string
 var publishDelay float32 = 10
 
 // If all current system discovery messages should be removed.
 var flagClearSystems bool
 
 func init() {
-	flag.BoolVar(&flagClearSystems, "c", false, "If all garden discovery messages should be cleared")
-
-	flag.Parse()
-}
-
-func main() {
+	// Setup logging
 	logrus.SetFormatter(&logrus.TextFormatter{
 		FullTimestamp: true,
 	})
 
 	logrus.SetLevel(logrus.DebugLevel)
 
+	// Parse CLI flags
+	flag.BoolVar(&flagClearSystems, "c", false, "If all garden discovery messages should be cleared")
+	flag.StringVar(&id, "i", "1234567890AB", "Sets the 12 character identifier for this system. Only 0-9 and A-F are permitted.")
+
+	flag.Parse()
+
+	if !util.SystemIdentifierRegex.MatchString(id) {
+		panic(fmt.Sprintf("provided identifier must match %s", &util.SystemIdentifierRegex))
+	}
+
+	baseTopic = "garden/module/" + id
+}
+
+func main() {
 	config.Load()
 	mqtt.Setup(false)
 

--- a/backend/internal/mqtt/mqtt.go
+++ b/backend/internal/mqtt/mqtt.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net"
 	"regexp"
 	"sort"
@@ -56,7 +57,9 @@ func Setup(isServer bool) {
 
 	clientId := "garden-backend"
 	if !isServer {
-		clientId = "123456"
+		// Generate a random client ID in the range 500,000 - 999,999
+		rand.Seed(time.Now().UnixMicro())
+		clientId = fmt.Sprintf("garden-client-%d", rand.Intn(500_000)+500_000)
 	}
 
 	logrus.Debugf("[mqtt] backend server mode: %t, using client id %s", isServer, clientId)
@@ -354,7 +357,7 @@ func handleMqttMessage(client, topic string, payload []byte) {
 func Subscribe(topic string, callback func(c mqtt.Client, m mqtt.Message)) {
 	logrus.Debugf("[mqtt] subscribing to topic %s", topic)
 
-	if token := mqttClient.Subscribe(topic, 0, callback); token.Wait() && token.Error() != nil {
+	if token := mqttClient.Subscribe(topic, 0, callback); token.WaitTimeout(2*time.Second) && token.Error() != nil {
 		panic(token.Error())
 	}
 }


### PR DESCRIPTION
The MAC address of the emulator can now be controlled through the `-i` flag.