### PR TITLE
Improve dashboard

### DIFF
--- a/frontend/src/components/NodeModule.vue
+++ b/frontend/src/components/NodeModule.vue
@@ -31,8 +31,10 @@
             </h2>
           </span>
           <p class="secondary-text">
-            Last pushed {{ timestamp }} seconds ago
-            <v-icon class="icon" small> mdi-clock </v-icon>
+            <tooltip :text="lastSeen">
+              Last pushed {{ humanize(timestamp) }}
+              <v-icon class="icon" small> mdi-clock </v-icon>
+            </tooltip>
           </p>
         </v-col>
       </v-row>
@@ -48,6 +50,18 @@ import Tooltip from "@/components/Tooltip.vue";
 export default Vue.extend({
   name: "NodeModule",
   components: { Tooltip },
+  data() {
+    return {
+      dateOptions: {
+        hour12: false
+      } as Intl.DateTimeFormatOptions,
+
+      // Maximum number of humanized duration portions to display. Higher values will be more accurate but
+      // take up more space. For example, if a node was last seen 4 weeks ago, do most users really care
+      // that it was *exactly* 4 weeks, 11 days, 13 hours, 7 minutes, 2 seconds ago?
+      maximumParts: 2
+    };
+  },
   props: [
     "moduleName",
     "identifier",
@@ -59,11 +73,91 @@ export default Vue.extend({
     meshInfo(announcement: GardenSystemInfo): string {
       const mesh = announcement.IsMesh;
       return mesh ? "Mesh" : `MQTT (CH ${announcement.Channel})`;
+    },
+    humanize(raw: number): string {
+      /* Example: suppose raw is 436507 (seconds).
+       * Step 1: floor(436507 / 86400) = 5 days.
+       * raw -= 5*86400. raw is now 4507
+       * Step 2: floor(4507 / 3600) = 1 hour.
+       * raw -= 1*3600. raw is now 907
+       * Step 3: floor(907 / 60) = 15 minutes.
+       * raw -= 15*60. raw is now 7 seconds.
+       *
+       * For all pushed parts, check if they need to be pluralized (almost certainly since only 1 doesn't need it).
+       * Combine those parts into the string "5 days, 1 hour, 15 minutes, 7 seconds".
+       * This is correct since 7 + 15*60 + 1*60*60 + 5*60*60*24 = 436507, which is exactly equal to the input value.
+       */
+
+      if (raw <= 2) {
+        return "now";
+      }
+
+      interface duration {
+        n: number;
+        s: string;
+      }
+
+      let parts: Array<duration> = [];
+
+      const steps = [
+        {
+          n: 60 * 60 * 24,
+          s: "day"
+        },
+        {
+          n: 60 * 60,
+          s: "hour"
+        },
+        {
+          n: 60,
+          s: "minute"
+        },
+        {
+          n: 1,
+          s: "second"
+        }
+      ] as Array<duration>;
+
+      // Convert the seconds into a human readable duration.
+      for (const step of steps) {
+        if (parts.length >= this.maximumParts) {
+          break;
+        }
+
+        const tmp = Math.floor(raw / step.n);
+        if (tmp == 0) {
+          continue;
+        }
+
+        parts.push({ n: tmp, s: step.s });
+        raw -= tmp * step.n;
+      }
+
+      // Fix grammar.
+      let humanized = "";
+      for (let i = 0; i < parts.length; i++) {
+        const p = parts[i];
+        if (p.n > 1) {
+          p.s += "s";
+        }
+
+        humanized += `${p.n} ${p.s}, `;
+      }
+
+      // Remove trailing comma.
+      return humanized.substring(0, humanized.length - 2) + " ago";
     }
   },
   computed: {
     state(): string {
       return this.isConnected ? "connected" : "disconnected";
+    },
+    lastSeen(): string {
+      const t = this.$props.timestamp * 1000; // seconds -> ms
+      return new Date(new Date().getTime() - t).toLocaleString(
+        undefined,
+        this.dateOptions
+      );
     }
   }
 });

--- a/frontend/src/components/NodeModule.vue
+++ b/frontend/src/components/NodeModule.vue
@@ -14,33 +14,22 @@
         <v-col>
           <h1>{{ moduleName }}</h1>
           <p class="secondary-text">
-            Id:
-            <router-link :to="'/graph/' + identifier">
-              <code>{{ identifier }}</code>
-            </router-link>
+            <code>{{ identifier }}</code>
           </p>
         </v-col>
         <v-col class="rhs" align-items="center">
-          <v-container v-if="isConnected">
-            <h2 class="connected">
+          <span>
+            <h2 :class="state">
               <tooltip :text="meshInfo(announcement)">
-                <span>
-                  Connected
-                  <v-icon class="icon"> mdi-wifi-check </v-icon>
+                <span class="moduleState">
+                  {{ state }}
+                  <v-icon class="icon">
+                    {{ isConnected ? "mdi-wifi-check" : "mdi-wifi-off" }}
+                  </v-icon>
                 </span>
               </tooltip>
             </h2>
-          </v-container>
-          <v-container v-else>
-            <h2 class="disconnected">
-              <tooltip :text="meshInfo(announcement)">
-                <span>
-                  Disconnected
-                  <v-icon class="icon"> mdi-wifi-off </v-icon>
-                </span>
-              </tooltip>
-            </h2>
-          </v-container>
+          </span>
           <p class="secondary-text">
             Last pushed {{ timestamp }} seconds ago
             <v-icon class="icon" small> mdi-clock </v-icon>
@@ -53,7 +42,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { GardenSystem, GardenSystemInfo } from "@/store/types";
+import { GardenSystemInfo } from "@/store/types";
 import Tooltip from "@/components/Tooltip.vue";
 
 export default Vue.extend({
@@ -67,9 +56,14 @@ export default Vue.extend({
     "announcement"
   ],
   methods: {
-    meshInfo(announcement: GardenSystemInfo): any {
+    meshInfo(announcement: GardenSystemInfo): string {
       const mesh = announcement.IsMesh;
       return mesh ? "Mesh" : `MQTT (CH ${announcement.Channel})`;
+    }
+  },
+  computed: {
+    state(): string {
+      return this.isConnected ? "connected" : "disconnected";
     }
   }
 });
@@ -96,18 +90,25 @@ p a {
 .node-icon {
   font-size: 4.5em;
 }
+
 h2.connected {
   color: $green-0;
   .icon {
     color: $green-0;
   }
 }
+
 h2.disconnected {
   color: $red-0;
   .icon {
     color: $red-0;
   }
 }
+
+span.moduleState {
+  text-transform: capitalize;
+}
+
 p .icon {
   padding-left: 0.25rem;
   color: $white-4;

--- a/frontend/src/components/NodeModule.vue
+++ b/frontend/src/components/NodeModule.vue
@@ -1,21 +1,27 @@
 <template>
   <router-link :to="'/system/' + identifier" custom v-slot="{ navigate }">
-  <v-card @click="navigate" @keypress.enter="navigate" v-ripple flat class="rounded-0 card">
-    <v-row class="parent-row">
-      <v-col md="auto" cols="auto">
-        <v-icon class="node-icon"> mdi-leaf </v-icon>
-      </v-col>
-      <v-col>
-        <h1>{{ moduleName }}</h1>
-        <p class="secondary-text">
-          Id:
-          <router-link :to="'/graph/' + identifier">
-            <code>{{ identifier }}</code>
-          </router-link>
-        </p>
-      </v-col>
-      <v-col class="rhs" align-items="center">
-        <v-container v-if="isConnected">
+    <v-card
+      @click="navigate"
+      @keypress.enter="navigate"
+      v-ripple
+      flat
+      class="rounded-0 card"
+    >
+      <v-row class="parent-row">
+        <v-col md="auto" cols="auto">
+          <v-icon class="node-icon"> mdi-leaf </v-icon>
+        </v-col>
+        <v-col>
+          <h1>{{ moduleName }}</h1>
+          <p class="secondary-text">
+            Id:
+            <router-link :to="'/graph/' + identifier">
+              <code>{{ identifier }}</code>
+            </router-link>
+          </p>
+        </v-col>
+        <v-col class="rhs" align-items="center">
+          <v-container v-if="isConnected">
             <h2 class="connected">
               <tooltip :text="meshInfo(announcement)">
                 <span>
@@ -24,8 +30,8 @@
                 </span>
               </tooltip>
             </h2>
-        </v-container>
-        <v-container v-else>
+          </v-container>
+          <v-container v-else>
             <h2 class="disconnected">
               <tooltip :text="meshInfo(announcement)">
                 <span>
@@ -34,14 +40,14 @@
                 </span>
               </tooltip>
             </h2>
-        </v-container>
-        <p class="secondary-text">
-          Last pushed {{ timestamp }} seconds ago
-          <v-icon class="icon" small> mdi-clock </v-icon>
-        </p>
-      </v-col>
-    </v-row>
-  </v-card>
+          </v-container>
+          <p class="secondary-text">
+            Last pushed {{ timestamp }} seconds ago
+            <v-icon class="icon" small> mdi-clock </v-icon>
+          </p>
+        </v-col>
+      </v-row>
+    </v-card>
   </router-link>
 </template>
 
@@ -50,16 +56,21 @@ import Vue from "vue";
 import { GardenSystem, GardenSystemInfo } from "@/store/types";
 import Tooltip from "@/components/Tooltip.vue";
 
-
 export default Vue.extend({
   name: "NodeModule",
   components: { Tooltip },
-  props: ["moduleName", "identifier", "isConnected", "timestamp", "announcement"],
+  props: [
+    "moduleName",
+    "identifier",
+    "isConnected",
+    "timestamp",
+    "announcement"
+  ],
   methods: {
     meshInfo(announcement: GardenSystemInfo): any {
       const mesh = announcement.IsMesh;
       return mesh ? "Mesh" : `MQTT (CH ${announcement.Channel})`;
-    },
+    }
   }
 });
 </script>

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -22,7 +22,7 @@ export default new Vuex.Store<StoreState>({
       // If we get here, it's because this is a new system, append it to the end of the array.
       state.systems.push(newClient);
     },
-    // A new client has joined the server, add it's information to our local state
+    // The server has sent the initial array of all systems.
     register(state, systems) {
       state.systems = systems;
     }

--- a/frontend/src/views/Systems.vue
+++ b/frontend/src/views/Systems.vue
@@ -1,26 +1,26 @@
 <template>
   <v-container>
     <h1>Module List</h1>
-    <div class="module-list-container"> 
-    <v-row no-gutters class="search-bar">
-      <v-col>
-        <input v-model="searchQuery" placeholder="Search for a module">
-      </v-col>
-      <v-col :cols="1">
-        <v-icon class="magnify"> mdi-magnify </v-icon>
-      </v-col>
-    </v-row>
-    <div v-for="sys in resultQuery" :key="sys.Identifier">
-      <node-module
+    <div class="module-list-container">
+      <v-row no-gutters class="search-bar">
+        <v-col>
+          <input v-model="searchQuery" placeholder="Search for a module" />
+        </v-col>
+        <v-col :cols="1">
+          <v-icon class="magnify"> mdi-magnify </v-icon>
+        </v-col>
+      </v-row>
+      <div v-for="sys in resultQuery" :key="sys.Identifier">
+        <node-module
           moduleName="Node Module"
           :identifier="sys.Identifier"
           :isConnected="isConnected(sys.UpdatedAt)"
           :timestamp="age(sys.UpdatedAt)"
           :announcement="sys.Announcement"
         />
+      </div>
     </div>
-    </div>
-    <br/>
+    <br />
 
     <span>Send command to:</span>
     <br />
@@ -229,12 +229,12 @@ export default Vue.extend({
       if (!this.searchQuery) {
         return this.$data.systems;
       }
-      
+
       return this.$data.systems.filter((item: GardenSystem) => {
         return this.searchQuery
           .toLowerCase()
           .split(" ")
-          .every(v => item.Identifier.toLowerCase().includes(v));
+          .every((v) => item.Identifier.toLowerCase().includes(v));
       });
     }
   }
@@ -242,9 +242,9 @@ export default Vue.extend({
 </script>
 
 <style scoped lang="scss">
-  h1 {
-    font-size: 3em;
-  }
+h1 {
+  font-size: 3em;
+}
 
 .search-bar {
   .magnify {

--- a/frontend/src/views/Systems.vue
+++ b/frontend/src/views/Systems.vue
@@ -45,12 +45,6 @@
       <v-icon>mdi-plus</v-icon>
     </v-btn>
 
-    <br />
-    <div style="max-width: 300px">
-      <h2>Temporary settings menu</h2>
-      <v-switch v-model="fahrenheit" label="Use Farenheit" />
-    </div>
-
     <command-dialog
       @command="sendCommandHandler"
       @close="command.show = false"
@@ -102,7 +96,6 @@ export default Vue.extend({
       ],
       searchQuery: "",
       showSystemTypes: false,
-      fahrenheit: (window.localStorage.getItem("units") ?? "C") == "F",
 
       command: {
         id: "",
@@ -171,15 +164,6 @@ export default Vue.extend({
     isReadingValid(reading: number): boolean {
       return reading != 32768;
     },
-    temp(reading: number): string {
-      const units = this.fahrenheit ? "F" : "C";
-
-      if (this.fahrenheit) {
-        reading = (9 / 5) * reading + 32;
-      }
-
-      return `${reading.toFixed(2)} °${units}`;
-    },
     sendCommand(id: string) {
       this.command.id = id;
       this.command.show = true;
@@ -208,11 +192,6 @@ export default Vue.extend({
     setInterval(() => {
       this.$forceUpdate();
     }, 5 * 1000);
-  },
-  watch: {
-    fahrenheit() {
-      window.localStorage.setItem("units", this.fahrenheit ? "F" : "C");
-    }
   },
   computed: {
     // search for node modules and return the result


### PR DESCRIPTION
**Changes**
* Remove old graph links from the node MAC address
* Align connection status with last pushed text
* Deduplicate connection status text & icons
* Humanize last pushed times
  * For example, a node that last pushed 436,507 seconds ago would display as "last pushed 5 days, 1 hour ago"

**Bug fixes**
* Fix the module list being blank after clicking a node and then pressing the back button

`main` branch:
![ui-before](https://user-images.githubusercontent.com/33811686/145153929-ea03efc4-5a77-432b-8dc1-f0ed9ee8bc5c.png)

This branch:
![ui-02](https://user-images.githubusercontent.com/33811686/145363296-03ecf88a-96e5-49eb-80fe-551fad681551.png)
