### PR TITLE
Add support for OTA firmware updates

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -8,12 +8,14 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.9.0
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b
 	gorm.io/driver/sqlite v1.1.6
 	gorm.io/gorm v1.21.16
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
@@ -22,6 +24,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.8 // indirect
 	github.com/mitchellh/mapstructure v1.4.2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
@@ -32,4 +35,5 @@ require (
 	golang.org/x/text v0.3.6 // indirect
 	gopkg.in/ini.v1 v1.63.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.9.0
+	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b
 	gorm.io/driver/sqlite v1.1.6
 	gorm.io/gorm v1.21.16
 )
@@ -26,7 +27,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
-	golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420 // indirect
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
 	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
 	golang.org/x/text v0.3.6 // indirect
 	gopkg.in/ini.v1 v1.63.2 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -290,6 +290,8 @@ golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b h1:QAqMVf3pSa6eeTsuklijukjXBlj7Es2QQplab+/RbQ4=
+golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -362,8 +364,9 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420 h1:a8jGStKg0XqKDlKqjLrXn0ioF5MH36pT7Z0BRTqLhbk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/backend/internal/api/command.go
+++ b/backend/internal/api/command.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"fmt"
+
+	"github.com/ConfusedPolarBear/garden/internal/db"
+	"github.com/ConfusedPolarBear/garden/internal/mqtt"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+func sendCommand(id, command string, encrypt bool) error {
+	if encrypt {
+		// Mesh messages are limited to 212 bytes in size. The nonce (12) + tag (16) drop that limit down to 184 bytes.
+		if len(command) > 184 {
+			return errors.New("encrypted commands cannot exceed 184 bytes")
+		}
+
+		config, err := db.GetConfiguration()
+		if err != nil {
+			return err
+		}
+
+		// Create the cipher.
+		// TODO: should be cached.
+		chacha, err := chacha20poly1305.New(config.ChaChaKey)
+		if err != nil {
+			return err
+		}
+
+		// Create the nonce and seal the box.
+		// Ensure that nulls and carriage returns aren't present because the C++ firmware can't handle them correctly
+		// and it will fail to authenticate the ciphertext.
+		// TODO: *properly* fix this.
+		var nonce, raw []byte
+		forbidden := "\x00\x0d"
+
+		for {
+			nonce, raw = nil, nil
+
+			nonce = make([]byte, chacha20poly1305.NonceSize)
+			if _, err := rand.Read(nonce); err != nil {
+				panic(err)
+			}
+
+			raw = chacha.Seal(raw, nonce, []byte(command), nil)
+
+			if !bytes.ContainsAny(nonce, forbidden) && !bytes.ContainsAny(raw, forbidden) {
+				break
+			}
+		}
+
+		// Garden systems expect nonce + tag + ciphertext, not nonce + ciphertext + tag. Swap the bytes to account for this.
+		start := len(raw) - 16
+		tag, ciphertext := raw[start:], raw[:start]
+
+		command = fmt.Sprintf("e%s%s%s", nonce, tag, ciphertext)
+	}
+
+	// Get the system
+	isMesh := false
+	if id != "FFFFFFFFFFFF" {
+		// If this is not a broadcast message, lookup the individual system to send the message to
+		system, err := db.GetSystem(id, false)
+		if err != nil {
+			return err
+		}
+
+		isMesh = system.Announcement.IsMesh
+	} else {
+		isMesh = true
+	}
+
+	logrus.Debugf("[server] sending command to %s: %s", id, command)
+
+	mqttDest := id
+	mqttPayload := command
+
+	// If this system is connected over MQTT, send the raw command
+	if isMesh {
+		// Mesh connected systems are controlled by sending a command (MQTT) to the coordinator who will rebroadcast it (ESP-NOW)
+		coordinator, err := db.GetCoordinator()
+		if err != nil {
+			return err
+		}
+
+		mqttDest = coordinator.Identifier
+
+		// +12 bytes for the MAC address and +4 bytes for "dst-"
+		logrus.Debugf("[server] mesh payload will be %d bytes long", len(mqttPayload)+12+4)
+
+		// Construct the mesh payload
+		mqttPayload = fmt.Sprintf(`{"Command":"Publish","Payload":"h%x"}`, "dst-"+id+mqttPayload)
+	}
+
+	logrus.Debugf("[server] commanding \"%s\"", mqttDest)
+	logrus.Debugf("[server] mqtt payload \"%s\"", mqttPayload)
+
+	mqtt.Publish(fmt.Sprintf("garden/module/%s/cmnd", mqttDest), mqttPayload)
+
+	return nil
+}

--- a/backend/internal/api/firmware.go
+++ b/backend/internal/api/firmware.go
@@ -20,6 +20,15 @@ func ManifestHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func DownloadFirmware(w http.ResponseWriter, r *http.Request) {
+	// Test if this is a short URL handler.
+	name := mux.CurrentRoute(r).GetName()
+	if name == "esp8266" || name == "esp32" {
+		sendFirmware(w, name, "firmware.bin")
+		return
+	}
+
+	// Since this is not a short URL handler, extract the parameters from the route & send that instead.
+
 	// Extract and validate the board name
 	board := mux.Vars(r)["board"]
 	if board != "esp32" && board != "esp8266" {
@@ -35,6 +44,10 @@ func DownloadFirmware(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	sendFirmware(w, board, file)
+}
+
+func sendFirmware(w http.ResponseWriter, board, file string) {
 	// Open the firmware binary
 	p := path.Join("data/firmware", board, file)
 

--- a/backend/internal/api/http.go
+++ b/backend/internal/api/http.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"bytes"
-	"crypto/rand"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,10 +9,8 @@ import (
 	"strings"
 
 	"github.com/ConfusedPolarBear/garden/internal/db"
-	"github.com/ConfusedPolarBear/garden/internal/mqtt"
 	"github.com/ConfusedPolarBear/garden/internal/util"
 	"github.com/ConfusedPolarBear/garden/internal/websocket"
-	"golang.org/x/crypto/chacha20poly1305"
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
@@ -31,7 +27,7 @@ func StartServer() {
 	r.HandleFunc("/systems", GetSystems).Methods("GET")
 	r.HandleFunc("/system/{id}", GetSystem).Methods("GET")
 	r.HandleFunc("/system/delete/{id}", DeleteSystem).Methods("POST")
-	r.HandleFunc("/system/command/{id}", SendCommand).Methods("POST", "OPTIONS")
+	r.HandleFunc("/system/command/{id}", SendCommandHandler).Methods("POST", "OPTIONS")
 	r.HandleFunc("/system/update/{id}", StartOTA).Methods("POST")
 
 	r.HandleFunc("/firmware/manifest.json", ManifestHandler).Methods("GET")
@@ -101,7 +97,7 @@ func DeleteSystem(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func SendCommand(w http.ResponseWriter, r *http.Request) {
+func SendCommandHandler(w http.ResponseWriter, r *http.Request) {
 	id, err := getId(w, r)
 	if err != nil {
 		return
@@ -120,104 +116,12 @@ func SendCommand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If the user wants to encrypt the command, do that now.
-	if r.Form.Has("encrypt") {
-		// Mesh messages are limited to 212 bytes in size. The nonce (12) + tag (16) drop that limit down to 184 bytes.
-		if len(command) > 184 {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
+	encrypt := r.Form.Has("encrypt")
 
-		config, err := db.GetConfiguration()
-		if err != nil {
-			logrus.Warnf("[server] unable to get configuration: %s", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		// Create the cipher.
-		// TODO: should be cached.
-		chacha, err := chacha20poly1305.New(config.ChaChaKey)
-		if err != nil {
-			logrus.Warnf("[crypto] unable to initialize cipher: %s", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		// Create the nonce and seal the box.
-		// Ensure that nulls and carriage returns aren't present because the C++ firmware can't handle them correctly
-		// and it will fail to authenticate the ciphertext.
-		// TODO: *properly* fix this.
-		var nonce, raw []byte
-		forbidden := "\x00\x0d"
-
-		for {
-			nonce, raw = nil, nil
-
-			nonce = make([]byte, chacha20poly1305.NonceSize)
-			if _, err := rand.Read(nonce); err != nil {
-				panic(err)
-			}
-
-			raw = chacha.Seal(raw, nonce, []byte(command), nil)
-
-			if !bytes.ContainsAny(nonce, forbidden) && !bytes.ContainsAny(raw, forbidden) {
-				break
-			}
-		}
-
-		// Garden systems expect nonce + tag + ciphertext, not nonce + ciphertext + tag. Swap the bytes to account for this.
-		start := len(raw) - 16
-		tag, ciphertext := raw[start:], raw[:start]
-
-		command = fmt.Sprintf("e%s%s%s", nonce, tag, ciphertext)
-
-		// logrus.Debugf("nonce is %X, tag is %X, and ciphertext is %X", nonce, tag, ciphertext)
+	if err := sendCommand(id, command, encrypt); err != nil {
+		logrus.Warnf("[server] unable to send command: %s", err)
+		w.WriteHeader(http.StatusBadRequest)
 	}
-
-	// Get the system
-	isMesh := false
-	if id != "FFFFFFFFFFFF" {
-		// If this is not a broadcast message, lookup the individual system to send the message to
-		system, err := db.GetSystem(id, false)
-		if err != nil {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-
-		isMesh = system.Announcement.IsMesh
-	} else {
-		isMesh = true
-	}
-
-	logrus.Debugf("[server] sending command to %s: %s", id, command)
-
-	mqttDest := id
-	mqttPayload := command
-
-	// If this system is connected over MQTT, send the raw command
-	if isMesh {
-		// Mesh connected systems are controlled by sending a command (MQTT) to the coordinator who will rebroadcast it (ESP-NOW)
-		coordinator, err := db.GetCoordinator()
-		if err != nil {
-			logrus.Errorf("[server] unable to find coordinator: %s", err)
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-
-		mqttDest = coordinator.Identifier
-
-		// +12 bytes for the MAC address and +4 bytes for "dst-"
-		logrus.Debugf("[server] mesh payload will be %d bytes long", len(mqttPayload)+12+4)
-
-		// Construct the mesh payload
-		mqttPayload = fmt.Sprintf(`{"Command":"Publish","Payload":"h%x"}`, "dst-"+id+mqttPayload)
-	}
-
-	logrus.Debugf("[server] commanding \"%s\"", mqttDest)
-	logrus.Debugf("[server] mqtt payload \"%s\"", mqttPayload)
-
-	mqtt.Publish(fmt.Sprintf("garden/module/%s/cmnd", mqttDest), mqttPayload)
 }
 
 func StartOTA(w http.ResponseWriter, r *http.Request) {
@@ -326,6 +230,9 @@ func StartOTA(w http.ResponseWriter, r *http.Request) {
 	ota.URL = fmt.Sprintf("%s/%s", host, shortCode)
 	logrus.Debugf("[server] set OTA url to %s (used host %s)", ota.URL, host)
 
-	// TODO: publish the command directly
-	w.Write(util.Marshal(ota))
+	if err := sendCommand(id, string(util.Marshal(ota)), true); err != nil {
+		logrus.Warnf("[server] unable to initiate OTA for %s: %s", id, err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 }

--- a/backend/internal/api/http.go
+++ b/backend/internal/api/http.go
@@ -28,7 +28,7 @@ func StartServer() {
 	r.HandleFunc("/system/{id}", GetSystem).Methods("GET")
 	r.HandleFunc("/system/delete/{id}", DeleteSystem).Methods("POST")
 	r.HandleFunc("/system/command/{id}", SendCommandHandler).Methods("POST", "OPTIONS")
-	r.HandleFunc("/system/update/{id}", StartOTA).Methods("POST")
+	r.HandleFunc("/system/update/{id}", StartOTA).Methods("POST", "OPTIONS")
 
 	r.HandleFunc("/firmware/manifest.json", ManifestHandler).Methods("GET")
 	r.HandleFunc("/firmware/{board}/{file}", DownloadFirmware).Methods("GET")

--- a/backend/internal/api/mesh.go
+++ b/backend/internal/api/mesh.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/ConfusedPolarBear/garden/internal/db"
+	"github.com/ConfusedPolarBear/garden/internal/util"
+
+	"github.com/sirupsen/logrus"
+)
+
+func MeshInfoHandler(w http.ResponseWriter, _ *http.Request) {
+	type meshInfo struct {
+		Key        string
+		Controller string
+		Channel    int
+	}
+
+	config, err := db.GetConfiguration()
+	if err != nil {
+		logrus.Errorf("[server] no configuration information found")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// TODO: support multiple coordinators & allow the user to pick which one they want
+	coordinator, err := db.GetCoordinator()
+	if err != nil {
+		logrus.Errorf("[server] no coordinators defined")
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	addr := util.IdentifierToAddress(coordinator.Identifier)
+
+	info := meshInfo{Key: config.MeshKey, Controller: addr, Channel: coordinator.Announcement.Channel}
+
+	w.Write(util.Marshal(info))
+}

--- a/backend/internal/db/config.go
+++ b/backend/internal/db/config.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"encoding/base64"
+
+	"github.com/ConfusedPolarBear/garden/internal/util"
+	"github.com/sirupsen/logrus"
+)
+
+func initializeConfig() {
+	var config util.Configuration
+	db.Limit(1).Find(&config)
+
+	if config.MeshKey != "" {
+		return
+	}
+
+	logrus.Print("[db] first run detected, initializing configuration")
+
+	config.MeshKey = base64.RawStdEncoding.EncodeToString(util.SecureRandom(48))
+
+	UpdateConfiguration(config)
+}
+
+func GetConfiguration() (util.Configuration, error) {
+	var config util.Configuration
+
+	err := db.First(&config).Error
+
+	if err == nil {
+		config.ChaChaKey = util.DeriveKey("chacha-symmetric-key", config.MeshKey)
+	}
+
+	return config, err
+}
+
+func UpdateConfiguration(config util.Configuration) error {
+	err := db.Save(&config).Error
+
+	if err != nil {
+		logrus.Errorf("[db] unable to save configuration: %s", err)
+	}
+
+	return err
+}

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -30,13 +30,19 @@ func InitializeDatabase() {
 	// TODO: support other database backends other than sqlite
 	db, err = gorm.Open(sqlite.Open("data/garden.db"), &gorm.Config{})
 	if err != nil {
-		logrus.Fatalf("[db] unable to open database: %s", db)
+		logrus.Fatalf("[db] unable to open database: %s", err)
 	}
 
 	logrus.Debug("[db] connected to database")
 
 	if err := db.AutoMigrate(&util.GardenSystem{}, &util.GardenSystemInfo{}, &util.Reading{}, &util.Sensor{}); err != nil {
 		panic(err)
+	}
+
+	if err := db.AutoMigrate(&util.Configuration{}); err != nil {
+		panic(err)
+	} else {
+		initializeConfig()
 	}
 
 	logrus.Debug("[db] migrations completed successfully")

--- a/backend/internal/mqtt/mqtt.go
+++ b/backend/internal/mqtt/mqtt.go
@@ -133,6 +133,7 @@ func handleMqttMessage(client, topic string, payload []byte) {
 		RestartReason       string `json:"RR"`
 		CoreVersion         string `json:"CV"`
 		SdkVersion          string `json:"SV"`
+		Chipset             string `json:"TY"`
 		FilesystemUsedSize  int    `json:"FU"`
 		FilesystemTotalSize int    `json:"FT"`
 		Sensors             []util.Sensor

--- a/backend/internal/util/config.go
+++ b/backend/internal/util/config.go
@@ -1,0 +1,11 @@
+package util
+
+type Configuration struct {
+	ID uint
+
+	// Raw mesh key. Used to authenticate mesh messages & derive all other keys.
+	MeshKey string
+
+	// Derived symmetric key for ChaCha20-Poly1305 operations.
+	ChaChaKey []byte `gorm:"-"`
+}

--- a/backend/internal/util/system.go
+++ b/backend/internal/util/system.go
@@ -13,7 +13,7 @@ var SystemIdentifierRegex regexp.Regexp = *regexp.MustCompile("^[a-fA-F0-9]{12}$
 
 type GardenSystem struct {
 	Identifier string `gorm:"primaryKey;notNull"`
-	Name string
+	Name       string
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 	DeletedAt  time.Time
@@ -41,6 +41,9 @@ type GardenSystemInfo struct {
 
 	CoreVersion string
 	SdkVersion  string
+
+	// The chipset this system uses. Currently either "ESP8266" or "ESP32".
+	Chipset string
 
 	FilesystemUsedSize  int
 	FilesystemTotalSize int

--- a/backend/internal/util/system.go
+++ b/backend/internal/util/system.go
@@ -22,6 +22,9 @@ type GardenSystem struct {
 
 	LastReading Reading `gorm:"-"`
 	Readings    []Reading
+
+	// Latest OTA status message received
+	UpdateStatus OTAStatus `gorm:"-"`
 }
 
 type GardenSystemInfo struct {
@@ -59,4 +62,9 @@ type Reading struct {
 	Error          bool
 	Temperature    float32
 	Humidity       float32
+}
+
+type OTAStatus struct {
+	Success  bool
+	Message string
 }

--- a/backend/internal/util/util.go
+++ b/backend/internal/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"crypto/hmac"
 	"crypto/md5"
 	"crypto/rand"
 	"crypto/sha256"
@@ -62,6 +63,16 @@ func SecureRandom(n int) []byte {
 	}
 
 	return buf
+}
+
+func DeriveKey(purpose, root string) []byte {
+	h := hmac.New(sha256.New, []byte(root))
+
+	if _, err := h.Write([]byte(purpose)); err != nil {
+		panic(err)
+	}
+
+	return h.Sum(nil)
 }
 
 func IdentifierToAddress(raw string) string {

--- a/backend/internal/util/util.go
+++ b/backend/internal/util/util.go
@@ -2,11 +2,13 @@ package util
 
 import (
 	"crypto/md5"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"os"
+	"strings"
 )
 
 // Marshal v or panic.
@@ -49,4 +51,25 @@ func SHA256(data []byte) string {
 	}
 
 	return hex.EncodeToString(sha256.Sum(nil))
+}
+
+// Returns a securely generated random buffer of length n.
+func SecureRandom(n int) []byte {
+	buf := make([]byte, n)
+
+	if _, err := rand.Read(buf); err != nil {
+		panic(err)
+	}
+
+	return buf
+}
+
+func IdentifierToAddress(raw string) string {
+	addr := ""
+	for i := 0; i < 12; i += 2 {
+		addr += raw[i:i+2] + ":"
+	}
+	addr = strings.TrimSuffix(addr, ":")
+
+	return addr
 }

--- a/backend/internal/util/util.go
+++ b/backend/internal/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"crypto/md5"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -24,6 +25,19 @@ func Mkdir(path string) error {
 	}
 
 	return nil
+}
+
+// Calculates the MD5 checksum of the input data or panic. Only present because the ESP8266 updater exclusively supports MD5.
+//
+// DO NOT USE FOR ANYTHING ELSE!
+func MD5(data []byte) string {
+	hasher := md5.New()
+
+	if _, err := hasher.Write(data); err != nil {
+		panic(err)
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil))
 }
 
 // Calculates the SHA256 hash of the input data or panic.

--- a/backend/internal/util/util_test.go
+++ b/backend/internal/util/util_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,5 +24,11 @@ func TestSHA256(t *testing.T) {
 func TestIdentifierToAddress(t *testing.T) {
 	expected := "84:cc:a8:ab:cd:ef"
 	actual := IdentifierToAddress("84cca8abcdef")
+	assert.Equal(t, expected, actual)
+}
+
+func TestKeyDerivation(t *testing.T) {
+	expected, _ := hex.DecodeString("d8eeaa25ed390dfdcad45f24697c45e94e4ee1788c67335aac0b287bb66ea4f0")
+	actual := DeriveKey("chacha-symmetric-key", "4B5DDWMTG346NBVFNIO4MPQ644RIBF52MJM6VATLH3DS2HPT76MF24TV5X7IMSI")
 	assert.Equal(t, expected, actual)
 }

--- a/backend/internal/util/util_test.go
+++ b/backend/internal/util/util_test.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var hashData string = "May the sinful saxophones of devils echo through the hall with dreadful melodies of waltz, tango and quickstep."
+
+func TestMD5(t *testing.T) {
+	expected := "8b3f18e7b961910fedd4370d588f269e"
+	actual := MD5([]byte(hashData))
+	assert.Equal(t, expected, actual)
+}
+
+func TestSHA256(t *testing.T) {
+	expected := "78f4209ef4a409b8f13fa8a4ce95aea2cac870315299eac7e40fba431b35f126"
+	actual := SHA256([]byte(hashData))
+	assert.Equal(t, expected, actual)
+}
+
+func TestIdentifierToAddress(t *testing.T) {
+	expected := "84:cc:a8:ab:cd:ef"
+	actual := IdentifierToAddress("84cca8abcdef")
+	assert.Equal(t, expected, actual)
+}

--- a/firmware/build_all.sh
+++ b/firmware/build_all.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+echo "Building all firmware binaries (debug mode)"
+pio run -e esp8266_debug -e esp32_debug
+
+echo "Copying to backend server directory"
+cp .pio/build/esp8266_debug/firmware.bin ../backend/data/firmware/esp8266/
+cp .pio/build/esp32_debug/firmware.bin ../backend/data/firmware/esp32/
+
+echo "Done"

--- a/firmware/include/crypto.h
+++ b/firmware/include/crypto.h
@@ -10,3 +10,6 @@ uint8_t* hmac(const uint8_t* data, size_t dataLength);
 
 // Compare two HMACs in constant time.
 bool hmacCompare(const uint8_t* lhs, const uint8_t* rhs);
+
+// Decrypts data encrypted with ChaCha20-Poly1305. Returns true when ciphertext is authentic & decrypts successfully.
+bool decrypt(const char* cipher, const size_t cipherLength, const char* nonce, const char* tag, char* output);

--- a/firmware/include/firmware.h
+++ b/firmware/include/firmware.h
@@ -41,6 +41,8 @@
 #define FILE_MESH_CHANNEL    "/meshChannel"
 #define FILE_MESH_KEY        "/meshKey"
 
+#define FILE_SECURE_MODE     "/secure"
+
 // ========== Command handling ==========
 // Checks if the Serial connection has a command. If it does, handle it.
 void parseSerial();

--- a/firmware/include/firmware.h
+++ b/firmware/include/firmware.h
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <queue>
 #include <vector>
 
 #include <Arduino.h>
@@ -46,6 +47,8 @@ void parseSerial();
 
 // Process a sent command.
 void processCommand(String command, bool secure = false);
+
+void queueCommand(String command);
 
 // ========== Utility functions ==========
 uint32_t secureRandom();

--- a/firmware/include/firmware.h
+++ b/firmware/include/firmware.h
@@ -24,6 +24,7 @@
 #include <mesh.h>
 #include <mqtt.h>
 #include <networking.h>
+#include <ota.h>
 #include <sensors.h>
 
 // ========== Paths to configuration files ==========
@@ -44,7 +45,7 @@
 void parseSerial();
 
 // Process a sent command.
-void processCommand(String command);
+void processCommand(String command, bool secure = false);
 
 // ========== Utility functions ==========
 uint32_t secureRandom();

--- a/firmware/include/firmware.h
+++ b/firmware/include/firmware.h
@@ -54,3 +54,12 @@ void queueCommand(String command);
 uint32_t secureRandom();
 String secureRandomNonce();
 void memzero(void* ptr, size_t size);
+void printMemoryStatistics(String msg);
+
+#define BUILTIN_LED 2
+
+// Flashes the onboard LED.
+void flashLed();
+
+// Delays for the provided amount of time without blocking background processes on the ESP.
+void safeDelay(const size_t time);

--- a/firmware/include/logger.h
+++ b/firmware/include/logger.h
@@ -3,8 +3,16 @@
 #include <Arduino.h>
 #include <Streaming.h>
 
-// Log a message to the Serial port at debug level.
-void LOGD(String tag, String message);
+#ifdef DEBUG
+#define LOGD(tag, msg) logAdvanced("D", tag, msg)
+#else
+#define LOGD(tag, msg)
+#endif
+
+void logAdvanced(String level, String tag, String message);
+
+// Logs an informational message.
+void LOGI(String tag, String message);
 
 // Log a warning.
 void LOGW(String tag, String message);

--- a/firmware/include/mqtt.h
+++ b/firmware/include/mqtt.h
@@ -16,7 +16,7 @@ void processMqtt();
 bool publish(String data, String teleTopic = "data");
 
 // Publish a JSON document over ESP-NOW or MQTT.
-bool publish(JsonDocument* doc, String teleTopic);
+bool publish(const JsonDocument& doc, const String teleTopic);
 
 // Returns the MQTT client identifier
 String getClientId();

--- a/firmware/include/mqtt.h
+++ b/firmware/include/mqtt.h
@@ -10,7 +10,7 @@ void connectToBroker();
 void mqttReceiveCallback(const MQTT::Publish& pub);
 
 // Process MQTT messages.
-void processMqtt();
+void processMqtt(bool rebootIfDisconnected = true);
 
 // Publish a message over ESP-NOW or MQTT.
 bool publish(String data, String teleTopic = "data");

--- a/firmware/include/mqtt.h
+++ b/firmware/include/mqtt.h
@@ -15,5 +15,8 @@ void processMqtt();
 // Publish a message over ESP-NOW or MQTT.
 bool publish(String data, String teleTopic = "data");
 
+// Publish a JSON document over ESP-NOW or MQTT.
+bool publish(JsonDocument* doc, String teleTopic);
+
 // Returns the MQTT client identifier
 String getClientId();

--- a/firmware/include/mqtt.h
+++ b/firmware/include/mqtt.h
@@ -4,7 +4,7 @@
 #include <PubSubClient.h>
 
 // Connect to the MQTT broker or restart.
-void connectToBroker(String host, String user, String pass);
+void connectToBroker();
 
 // Callback when a MQTT message has been received.
 void mqttReceiveCallback(const MQTT::Publish& pub);

--- a/firmware/include/networking.h
+++ b/firmware/include/networking.h
@@ -3,7 +3,11 @@
 void connectToWifi();
 void startAccessPoint(int channel);
 void stopAccessPoint();
+
 void startNetworkScan();
 void processNetworkScan();
+
 void sendDiscoveryMessage(bool useMqtt);
+
 String getIdentifier(bool includeColons = false);
+int getMeshChannel();

--- a/firmware/include/networking.h
+++ b/firmware/include/networking.h
@@ -6,3 +6,4 @@ void stopAccessPoint();
 void startNetworkScan();
 void processNetworkScan();
 void sendDiscoveryMessage(bool useMqtt);
+String getIdentifier(bool includeColons = false);

--- a/firmware/include/networking.h
+++ b/firmware/include/networking.h
@@ -1,5 +1,6 @@
 #pragma once
 
+void connectToWifi();
 void startAccessPoint(int channel);
 void stopAccessPoint();
 void startNetworkScan();

--- a/firmware/include/ota.h
+++ b/firmware/include/ota.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "firmware.h"
+
+// Returns a human readable string describing the update result.
+String getUpdateMessage();
+
+// Starts an OTA firmware update by connecting to the specified Wi-Fi network and downloading the firmware from the URL.
+// The firmware's integrity is verified with the provided MD5 checksum.
+void startUpdate(String wifi, String psk, String url, size_t length, String hash);

--- a/firmware/lib/Crypto/AuthenticatedCipher.cpp
+++ b/firmware/lib/Crypto/AuthenticatedCipher.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "AuthenticatedCipher.h"
+
+/**
+ * \class AuthenticatedCipher AuthenticatedCipher.h <AuthenticatedCipher.h>
+ * \brief Abstract base class for authenticated ciphers.
+ *
+ * This class abstracts the details of algorithms that provide Authenticated
+ * Encryption with Associated Data (AEAD).  Such algorithms combine
+ * encryption with message authentication to provide a single primitive.
+ *
+ * Authenticated ciphers have four parameters: the secret key, an
+ * initialization vector (called a "nonce" in the literature), the
+ * plaintext, and some associated data which is to be authenticated
+ * with the plaintext but not encrypted.  Associated data might be
+ * sequence numbers, IP addresses, protocol versions, or other information
+ * that is not secret but is important and unique to the session.
+ *
+ * Subclasses encrypt the plaintext content and output the ciphertext.
+ * Once all plaintext has been processed, the caller should invoke
+ * computeTag() to obtain the authentication tag to transmit with
+ * the ciphertext.  When the ciphertext is later decrypted, the checkTag()
+ * function can be used to check that the data is authentic.
+ *
+ * Reference: <a href="http://tools.ietf.org/html/rfc5116">RFC 5116</a>
+ *
+ * \sa Cipher
+ */
+
+/**
+ * \brief Constructs a new authenticated cipher.
+ */
+AuthenticatedCipher::AuthenticatedCipher()
+{
+}
+
+/**
+ * \brief Destroys this authenticated cipher.
+ */
+AuthenticatedCipher::~AuthenticatedCipher()
+{
+}
+
+/**
+ * \fn size_t AuthenticatedCipher::tagSize() const
+ * \brief Returns the size of the authentication tag.
+ *
+ * \return The size of the authentication tag in bytes.
+ *
+ * By default this function should return the largest tag size supported
+ * by the authenticated cipher.
+ *
+ * \sa computeTag()
+ */
+
+/**
+ * \fn void AuthenticatedCipher::addAuthData(const void *data, size_t len)
+ * \brief Adds extra data that will be authenticated but not encrypted.
+ *
+ * \param data The extra data to be authenticated.
+ * \param len The number of bytes of extra data to be authenticated.
+ *
+ * This function must be called before the first call to encrypt() or
+ * decrypt().  That is, it is assumed that all extra data for authentication
+ * is available before the first payload data block and that it will be
+ * prepended to the payload for authentication.  If the subclass needs to
+ * process the extra data after the payload, then it is responsible for saving
+ * \a data away until it is needed during computeTag() or checkTag().
+ *
+ * This function can be called multiple times with separate extra data
+ * blocks for authentication.  All such data will be concatenated into a
+ * single block for authentication purposes.
+ */
+
+/**
+ * \fn void AuthenticatedCipher::computeTag(void *tag, size_t len)
+ * \brief Finalizes the encryption process and computes the authentication tag.
+ *
+ * \param tag Points to the buffer to write the tag to.
+ * \param len The length of the tag, which may be less than tagSize() to
+ * truncate the tag to the first \a len bytes.
+ *
+ * \sa checkTag()
+ */
+
+/**
+ * \fn bool AuthenticatedCipher::checkTag(const void *tag, size_t len)
+ * \brief Finalizes the decryption process and checks the authentication tag.
+ *
+ * \param tag The tag value from the incoming ciphertext to be checked.
+ * \param len The length of the tag value in bytes, which may be less
+ * than tagSize().
+ *
+ * \return Returns true if the \a tag is identical to the first \a len
+ * bytes of the authentication tag that was calculated during the
+ * decryption process.  Returns false otherwise.
+ *
+ * This function must be called after the final block of ciphertext is
+ * passed to decrypt() to determine if the data could be authenticated.
+ *
+ * \note Authenticated cipher modes usually require that if the tag could
+ * not be verified, then all of the data that was previously decrypted
+ * <i>must</i> be discarded.  It is unwise to use the decrypted data for
+ * any purpose before it can be verified.  Callers are responsible for
+ * ensuring that any data returned via previous calls to decrypt() is
+ * discarded if checkTag() returns false.
+ *
+ * \sa computeTag()
+ */

--- a/firmware/lib/Crypto/AuthenticatedCipher.h
+++ b/firmware/lib/Crypto/AuthenticatedCipher.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CRYPTO_AUTHENTICATEDCIPHER_h
+#define CRYPTO_AUTHENTICATEDCIPHER_h
+
+#include "Cipher.h"
+
+class AuthenticatedCipher : public Cipher
+{
+public:
+    AuthenticatedCipher();
+    virtual ~AuthenticatedCipher();
+
+    virtual size_t tagSize() const = 0;
+
+    virtual void addAuthData(const void *data, size_t len) = 0;
+
+    virtual void computeTag(void *tag, size_t len) = 0;
+    virtual bool checkTag(const void *tag, size_t len) = 0;
+};
+
+#endif

--- a/firmware/lib/Crypto/BigNumberUtil.cpp
+++ b/firmware/lib/Crypto/BigNumberUtil.cpp
@@ -1,0 +1,769 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "BigNumberUtil.h"
+#include "utility/EndianUtil.h"
+#include "utility/LimbUtil.h"
+#include <string.h>
+
+/**
+ * \class BigNumberUtil BigNumberUtil.h <BigNumberUtil.h>
+ * \brief Utilities to assist with implementing big number arithmetic.
+ *
+ * Big numbers are represented as arrays of limb_t words, which may be
+ * 8 bits, 16 bits, or 32 bits in size depending upon how the library
+ * was configured.  For AVR, 16 bit limbs usually give the best performance.
+ *
+ * Limb arrays are ordered from the least significant word to the most
+ * significant.
+ */
+
+/**
+ * \brief Unpacks the little-endian byte representation of a big number
+ * into a limb array.
+ *
+ * \param limbs The limb array, starting with the least significant word.
+ * \param count The number of elements in the \a limbs array.
+ * \param bytes The bytes to unpack.
+ * \param len The number of bytes to unpack.
+ *
+ * If \a len is shorter than the length of \a limbs, then the high bytes
+ * will be filled with zeroes.  If \a len is longer than the length of
+ * \a limbs, then the high bytes will be truncated and lost.
+ *
+ * \sa packLE(), unpackBE()
+ */
+void BigNumberUtil::unpackLE(limb_t *limbs, size_t count,
+                             const uint8_t *bytes, size_t len)
+{
+#if BIGNUMBER_LIMB_8BIT
+    if (len < count) {
+        memcpy(limbs, bytes, len);
+        memset(limbs + len, 0, count - len);
+    } else {
+        memcpy(limbs, bytes, count);
+    }
+#elif CRYPTO_LITTLE_ENDIAN
+    count *= sizeof(limb_t);
+    if (len < count) {
+        memcpy(limbs, bytes, len);
+        memset(((uint8_t *)limbs) + len, 0, count - len);
+    } else {
+        memcpy(limbs, bytes, count);
+    }
+#elif BIGNUMBER_LIMB_16BIT
+    while (count > 0 && len >= 2) {
+        *limbs++ = ((limb_t)(bytes[0])) |
+                  (((limb_t)(bytes[1])) << 8);
+        bytes += 2;
+        --count;
+        len -= 2;
+    }
+    if (count > 0 && len == 1) {
+        *limbs++ = ((limb_t)(bytes[0]));
+        --count;
+    }
+    while (count > 0) {
+        *limbs++ = 0;
+        --count;
+    }
+#elif BIGNUMBER_LIMB_32BIT
+    while (count > 0 && len >= 4) {
+        *limbs++ = ((limb_t)(bytes[0])) |
+                  (((limb_t)(bytes[1])) <<  8) |
+                  (((limb_t)(bytes[2])) << 16) |
+                  (((limb_t)(bytes[3])) << 24);
+        bytes += 4;
+        --count;
+        len -= 4;
+    }
+    if (count > 0 && len > 0) {
+        if (len == 3) {
+            *limbs++ = ((limb_t)(bytes[0])) |
+                      (((limb_t)(bytes[1])) <<  8) |
+                      (((limb_t)(bytes[2])) << 16);
+        } else if (len == 2) {
+            *limbs++ = ((limb_t)(bytes[0])) |
+                      (((limb_t)(bytes[1])) <<  8);
+        } else {
+            *limbs++ = ((limb_t)(bytes[0]));
+        }
+        --count;
+    }
+    while (count > 0) {
+        *limbs++ = 0;
+        --count;
+    }
+#elif BIGNUMBER_LIMB_64BIT
+    while (count > 0 && len >= 8) {
+        *limbs++ = ((limb_t)(bytes[0])) |
+                  (((limb_t)(bytes[1])) <<  8) |
+                  (((limb_t)(bytes[2])) << 16) |
+                  (((limb_t)(bytes[3])) << 24) |
+                  (((limb_t)(bytes[4])) << 32) |
+                  (((limb_t)(bytes[5])) << 40) |
+                  (((limb_t)(bytes[6])) << 48) |
+                  (((limb_t)(bytes[7])) << 56);
+        bytes += 8;
+        --count;
+        len -= 8;
+    }
+    if (count > 0 && len > 0) {
+        limb_t word = 0;
+        uint8_t shift = 0;
+        while (len > 0 && shift < 64) {
+            word |= (((limb_t)(*bytes++)) << shift);
+            shift += 8;
+            --len;
+        }
+        *limbs++ = word;
+        --count;
+    }
+    while (count > 0) {
+        *limbs++ = 0;
+        --count;
+    }
+#endif
+}
+
+/**
+ * \brief Unpacks the big-endian byte representation of a big number
+ * into a limb array.
+ *
+ * \param limbs The limb array, starting with the least significant word.
+ * \param count The number of elements in the \a limbs array.
+ * \param bytes The bytes to unpack.
+ * \param len The number of bytes to unpack.
+ *
+ * If \a len is shorter than the length of \a limbs, then the high bytes
+ * will be filled with zeroes.  If \a len is longer than the length of
+ * \a limbs, then the high bytes will be truncated and lost.
+ *
+ * \sa packBE(), unpackLE()
+ */
+void BigNumberUtil::unpackBE(limb_t *limbs, size_t count,
+                             const uint8_t *bytes, size_t len)
+{
+#if BIGNUMBER_LIMB_8BIT
+    while (count > 0 && len > 0) {
+        --count;
+        --len;
+        *limbs++ = bytes[len];
+    }
+    memset(limbs, 0, count);
+#elif BIGNUMBER_LIMB_16BIT
+    bytes += len;
+    while (count > 0 && len >= 2) {
+        --count;
+        bytes -= 2;
+        len -= 2;
+        *limbs++ = ((limb_t)(bytes[1])) |
+                  (((limb_t)(bytes[0])) << 8);
+    }
+    if (count > 0 && len == 1) {
+        --count;
+        --bytes;
+        *limbs++ = (limb_t)(bytes[0]);
+    }
+    memset(limbs, 0, count * sizeof(limb_t));
+#elif BIGNUMBER_LIMB_32BIT
+    bytes += len;
+    while (count > 0 && len >= 4) {
+        --count;
+        bytes -= 4;
+        len -= 4;
+        *limbs++ = ((limb_t)(bytes[3])) |
+                  (((limb_t)(bytes[2])) << 8) |
+                  (((limb_t)(bytes[1])) << 16) |
+                  (((limb_t)(bytes[0])) << 24);
+    }
+    if (count > 0) {
+        if (len == 3) {
+            --count;
+            bytes -= 3;
+            *limbs++ = ((limb_t)(bytes[2])) |
+                      (((limb_t)(bytes[1])) << 8) |
+                      (((limb_t)(bytes[0])) << 16);
+        } else if (len == 2) {
+            --count;
+            bytes -= 2;
+            *limbs++ = ((limb_t)(bytes[1])) |
+                      (((limb_t)(bytes[0])) << 8);
+        } else if (len == 1) {
+            --count;
+            --bytes;
+            *limbs++ = (limb_t)(bytes[0]);
+        }
+    }
+    memset(limbs, 0, count * sizeof(limb_t));
+#elif BIGNUMBER_LIMB_64BIT
+    bytes += len;
+    while (count > 0 && len >= 8) {
+        --count;
+        bytes -= 8;
+        len -= 8;
+        *limbs++ = ((limb_t)(bytes[7])) |
+                  (((limb_t)(bytes[6])) << 8) |
+                  (((limb_t)(bytes[5])) << 16) |
+                  (((limb_t)(bytes[4])) << 24) |
+                  (((limb_t)(bytes[3])) << 32) |
+                  (((limb_t)(bytes[2])) << 40) |
+                  (((limb_t)(bytes[1])) << 48) |
+                  (((limb_t)(bytes[0])) << 56);
+    }
+    if (count > 0 && len > 0) {
+        limb_t word = 0;
+        uint8_t shift = 0;
+        while (len > 0 && shift < 64) {
+            word |= (((limb_t)(*(--bytes))) << shift);
+            shift += 8;
+            --len;
+        }
+        *limbs++ = word;
+        --count;
+    }
+    memset(limbs, 0, count * sizeof(limb_t));
+#endif
+}
+
+/**
+ * \brief Packs the little-endian byte representation of a big number
+ * into a byte array.
+ *
+ * \param bytes The byte array to pack into.
+ * \param len The number of bytes in the destination \a bytes array.
+ * \param limbs The limb array representing the big number, starting with
+ * the least significant word.
+ * \param count The number of elements in the \a limbs array.
+ *
+ * If \a len is shorter than the length of \a limbs, then the number will
+ * be truncated to the least significant \a len bytes.  If \a len is longer
+ * than the length of \a limbs, then the high bytes will be filled with zeroes.
+ *
+ * \sa unpackLE(), packBE()
+ */
+void BigNumberUtil::packLE(uint8_t *bytes, size_t len,
+                           const limb_t *limbs, size_t count)
+{
+#if BIGNUMBER_LIMB_8BIT
+    if (len <= count) {
+        memcpy(bytes, limbs, len);
+    } else {
+        memcpy(bytes, limbs, count);
+        memset(bytes + count, 0, len - count);
+    }
+#elif CRYPTO_LITTLE_ENDIAN
+    count *= sizeof(limb_t);
+    if (len <= count) {
+        memcpy(bytes, limbs, len);
+    } else {
+        memcpy(bytes, limbs, count);
+        memset(bytes + count, 0, len - count);
+    }
+#elif BIGNUMBER_LIMB_16BIT
+    limb_t word;
+    while (count > 0 && len >= 2) {
+        word = *limbs++;
+        bytes[0] = (uint8_t)word;
+        bytes[1] = (uint8_t)(word >> 8);
+        --count;
+        len -= 2;
+        bytes += 2;
+    }
+    if (count > 0 && len == 1) {
+        bytes[0] = (uint8_t)(*limbs);
+        --len;
+        ++bytes;
+    }
+    memset(bytes, 0, len);
+#elif BIGNUMBER_LIMB_32BIT
+    limb_t word;
+    while (count > 0 && len >= 4) {
+        word = *limbs++;
+        bytes[0] = (uint8_t)word;
+        bytes[1] = (uint8_t)(word >> 8);
+        bytes[2] = (uint8_t)(word >> 16);
+        bytes[3] = (uint8_t)(word >> 24);
+        --count;
+        len -= 4;
+        bytes += 4;
+    }
+    if (count > 0) {
+        if (len == 3) {
+            word = *limbs;
+            bytes[0] = (uint8_t)word;
+            bytes[1] = (uint8_t)(word >> 8);
+            bytes[2] = (uint8_t)(word >> 16);
+            len -= 3;
+            bytes += 3;
+        } else if (len == 2) {
+            word = *limbs;
+            bytes[0] = (uint8_t)word;
+            bytes[1] = (uint8_t)(word >> 8);
+            len -= 2;
+            bytes += 2;
+        } else if (len == 1) {
+            bytes[0] = (uint8_t)(*limbs);
+            --len;
+            ++bytes;
+        }
+    }
+    memset(bytes, 0, len);
+#elif BIGNUMBER_LIMB_64BIT
+    limb_t word;
+    while (count > 0 && len >= 8) {
+        word = *limbs++;
+        bytes[0] = (uint8_t)word;
+        bytes[1] = (uint8_t)(word >> 8);
+        bytes[2] = (uint8_t)(word >> 16);
+        bytes[3] = (uint8_t)(word >> 24);
+        bytes[4] = (uint8_t)(word >> 32);
+        bytes[5] = (uint8_t)(word >> 40);
+        bytes[6] = (uint8_t)(word >> 48);
+        bytes[7] = (uint8_t)(word >> 56);
+        --count;
+        len -= 8;
+        bytes += 8;
+    }
+    if (count > 0) {
+        word = *limbs;
+        while (len > 0) {
+            *bytes++ = (uint8_t)word;
+            word >>= 8;
+            --len;
+        }
+    }
+    memset(bytes, 0, len);
+#endif
+}
+
+/**
+ * \brief Packs the big-endian byte representation of a big number
+ * into a byte array.
+ *
+ * \param bytes The byte array to pack into.
+ * \param len The number of bytes in the destination \a bytes array.
+ * \param limbs The limb array representing the big number, starting with
+ * the least significant word.
+ * \param count The number of elements in the \a limbs array.
+ *
+ * If \a len is shorter than the length of \a limbs, then the number will
+ * be truncated to the least significant \a len bytes.  If \a len is longer
+ * than the length of \a limbs, then the high bytes will be filled with zeroes.
+ *
+ * \sa unpackLE(), packBE()
+ */
+void BigNumberUtil::packBE(uint8_t *bytes, size_t len,
+                           const limb_t *limbs, size_t count)
+{
+#if BIGNUMBER_LIMB_8BIT
+    if (len > count) {
+        size_t size = len - count;
+        memset(bytes, 0, size);
+        len -= size;
+        bytes += size;
+    } else if (len < count) {
+        count = len;
+    }
+    limbs += count;
+    while (count > 0) {
+        --count;
+        *bytes++ = *(--limbs);
+    }
+#elif BIGNUMBER_LIMB_16BIT
+    size_t countBytes = count * sizeof(limb_t);
+    limb_t word;
+    if (len >= countBytes) {
+        size_t size = len - countBytes;
+        memset(bytes, 0, size);
+        len -= size;
+        bytes += size;
+        limbs += count;
+    } else {
+        count = len / sizeof(limb_t);
+        limbs += count;
+        if ((len & 1) != 0)
+            *bytes++ = (uint8_t)(*limbs);
+    }
+    while (count > 0) {
+        --count;
+        word = *(--limbs);
+        *bytes++ = (uint8_t)(word >> 8);
+        *bytes++ = (uint8_t)word;
+    }
+#elif BIGNUMBER_LIMB_32BIT
+    size_t countBytes = count * sizeof(limb_t);
+    limb_t word;
+    if (len >= countBytes) {
+        size_t size = len - countBytes;
+        memset(bytes, 0, size);
+        len -= size;
+        bytes += size;
+        limbs += count;
+    } else {
+        count = len / sizeof(limb_t);
+        limbs += count;
+        if ((len & 3) == 3) {
+            word = *limbs;
+            *bytes++ = (uint8_t)(word >> 16);
+            *bytes++ = (uint8_t)(word >> 8);
+            *bytes++ = (uint8_t)word;
+        } else if ((len & 3) == 2) {
+            word = *limbs;
+            *bytes++ = (uint8_t)(word >> 8);
+            *bytes++ = (uint8_t)word;
+        } else if ((len & 3) == 1) {
+            *bytes++ = (uint8_t)(*limbs);
+        }
+    }
+    while (count > 0) {
+        --count;
+        word = *(--limbs);
+        *bytes++ = (uint8_t)(word >> 24);
+        *bytes++ = (uint8_t)(word >> 16);
+        *bytes++ = (uint8_t)(word >> 8);
+        *bytes++ = (uint8_t)word;
+    }
+#elif BIGNUMBER_LIMB_64BIT
+    size_t countBytes = count * sizeof(limb_t);
+    limb_t word;
+    if (len >= countBytes) {
+        size_t size = len - countBytes;
+        memset(bytes, 0, size);
+        len -= size;
+        bytes += size;
+        limbs += count;
+    } else {
+        count = len / sizeof(limb_t);
+        limbs += count;
+        uint8_t size = len & 7;
+        uint8_t shift = size * 8;
+        word = *limbs;
+        while (size > 0) {
+            shift -= 8;
+            *bytes++ = (uint8_t)(word >> shift);
+            --size;
+        }
+    }
+    while (count > 0) {
+        --count;
+        word = *(--limbs);
+        *bytes++ = (uint8_t)(word >> 56);
+        *bytes++ = (uint8_t)(word >> 48);
+        *bytes++ = (uint8_t)(word >> 40);
+        *bytes++ = (uint8_t)(word >> 32);
+        *bytes++ = (uint8_t)(word >> 24);
+        *bytes++ = (uint8_t)(word >> 16);
+        *bytes++ = (uint8_t)(word >> 8);
+        *bytes++ = (uint8_t)word;
+    }
+#endif
+}
+
+/**
+ * \brief Adds two big numbers.
+ *
+ * \param result The result of the addition.  This can be the same
+ * as either \a x or \a y.
+ * \param x The first big number.
+ * \param y The second big number.
+ * \param size The size of the values in limbs.
+ *
+ * \return Returns 1 if there was a carry out or 0 if there was no carry out.
+ *
+ * \sa sub(), mul()
+ */
+limb_t BigNumberUtil::add(limb_t *result, const limb_t *x,
+                          const limb_t *y, size_t size)
+{
+    dlimb_t carry = 0;
+    while (size > 0) {
+        carry += *x++;
+        carry += *y++;
+        *result++ = (limb_t)carry;
+        carry >>= LIMB_BITS;
+        --size;
+    }
+    return (limb_t)carry;
+}
+
+/**
+ * \brief Subtracts one big number from another.
+ *
+ * \param result The result of the subtraction.  This can be the same
+ * as either \a x or \a y.
+ * \param x The first big number.
+ * \param y The second big number to subtract from \a x.
+ * \param size The size of the values in limbs.
+ *
+ * \return Returns 1 if there was a borrow, or 0 if there was no borrow.
+ *
+ * \sa add(), mul()
+ */
+limb_t BigNumberUtil::sub(limb_t *result, const limb_t *x,
+                          const limb_t *y, size_t size)
+{
+    dlimb_t borrow = 0;
+    while (size > 0) {
+        borrow = ((dlimb_t)(*x++)) - (*y++) - ((borrow >> LIMB_BITS) & 0x01);
+        *result++ = (limb_t)borrow;
+        --size;
+    }
+    return ((limb_t)(borrow >> LIMB_BITS)) & 0x01;
+}
+
+/**
+ * \brief Multiplies two big numbers.
+ *
+ * \param result The result of the multiplication.  The array must be
+ * \a xcount + \a ycount limbs in size.
+ * \param x Points to the first value to multiply.
+ * \param xcount The number of limbs in \a x.
+ * \param y Points to the second value to multiply.
+ * \param ycount The number of limbs in \a y.
+ *
+ * \sa mul_P()
+ */
+void BigNumberUtil::mul(limb_t *result, const limb_t *x, size_t xcount,
+                        const limb_t *y, size_t ycount)
+{
+    size_t i, j;
+    dlimb_t carry;
+    limb_t word;
+    const limb_t *xx;
+    limb_t *rr;
+
+    // Multiply the lowest limb of y by x.
+    carry = 0;
+    word = y[0];
+    xx = x;
+    rr = result;
+    for (i = 0; i < xcount; ++i) {
+        carry += ((dlimb_t)(*xx++)) * word;
+        *rr++ = (limb_t)carry;
+        carry >>= LIMB_BITS;
+    }
+    *rr = (limb_t)carry;
+
+    // Multiply and add the remaining limbs of y by x.
+    for (i = 1; i < ycount; ++i) {
+        word = y[i];
+        carry = 0;
+        xx = x;
+        rr = result + i;
+        for (j = 0; j < xcount; ++j) {
+            carry += ((dlimb_t)(*xx++)) * word;
+            carry += *rr;
+            *rr++ = (limb_t)carry;
+            carry >>= LIMB_BITS;
+        }
+        *rr = (limb_t)carry;
+    }
+}
+
+/**
+ * \brief Reduces \a x modulo \a y using subtraction.
+ *
+ * \param result The result of the reduction.  This can be the
+ * same as \a x.
+ * \param x The number to be reduced.
+ * \param y The base to use for the modulo reduction.
+ * \param size The size of the values in limbs.
+ *
+ * It is assumed that \a x is less than \a y * 2 so that a single
+ * conditional subtraction will bring it down below \a y.  The reduction
+ * is performed in constant time.
+ *
+ * \sa reduceQuick_P()
+ */
+void BigNumberUtil::reduceQuick(limb_t *result, const limb_t *x,
+                                const limb_t *y, size_t size)
+{
+    // Subtract "y" from "x" and turn the borrow into an AND mask.
+    limb_t mask = sub(result, x, y, size);
+    mask = (~mask) + 1;
+
+    // Add "y" back to the result if the mask is non-zero.
+    dlimb_t carry = 0;
+    while (size > 0) {
+        carry += *result;
+        carry += (*y++ & mask);
+        *result++ = (limb_t)carry;
+        carry >>= LIMB_BITS;
+        --size;
+    }
+}
+
+/**
+ * \brief Adds two big numbers where one of them is in program memory.
+ *
+ * \param result The result of the addition.  This can be the same as \a x.
+ * \param x The first big number.
+ * \param y The second big number.  This must point into program memory.
+ * \param size The size of the values in limbs.
+ *
+ * \return Returns 1 if there was a carry out or 0 if there was no carry out.
+ *
+ * \sa sub_P(), mul_P()
+ */
+limb_t BigNumberUtil::add_P(limb_t *result, const limb_t *x,
+                            const limb_t *y, size_t size)
+{
+    dlimb_t carry = 0;
+    while (size > 0) {
+        carry += *x++;
+        carry += pgm_read_limb(y++);
+        *result++ = (limb_t)carry;
+        carry >>= LIMB_BITS;
+        --size;
+    }
+    return (limb_t)carry;
+}
+
+/**
+ * \brief Subtracts one big number from another where one is in program memory.
+ *
+ * \param result The result of the subtraction.  This can be the same as \a x.
+ * \param x The first big number.
+ * \param y The second big number to subtract from \a x.  This must point
+ * into program memory.
+ * \param size The size of the values in limbs.
+ *
+ * \return Returns 1 if there was a borrow, or 0 if there was no borrow.
+ *
+ * \sa add_P(), mul_P()
+ */
+limb_t BigNumberUtil::sub_P(limb_t *result, const limb_t *x,
+                            const limb_t *y, size_t size)
+{
+    dlimb_t borrow = 0;
+    while (size > 0) {
+        borrow = ((dlimb_t)(*x++)) - pgm_read_limb(y++) - ((borrow >> LIMB_BITS) & 0x01);
+        *result++ = (limb_t)borrow;
+        --size;
+    }
+    return ((limb_t)(borrow >> LIMB_BITS)) & 0x01;
+}
+
+/**
+ * \brief Multiplies two big numbers where one is in program memory.
+ *
+ * \param result The result of the multiplication.  The array must be
+ * \a xcount + \a ycount limbs in size.
+ * \param x Points to the first value to multiply.
+ * \param xcount The number of limbs in \a x.
+ * \param y Points to the second value to multiply.  This must point
+ * into program memory.
+ * \param ycount The number of limbs in \a y.
+ *
+ * \sa mul()
+ */
+void BigNumberUtil::mul_P(limb_t *result, const limb_t *x, size_t xcount,
+                          const limb_t *y, size_t ycount)
+{
+    size_t i, j;
+    dlimb_t carry;
+    limb_t word;
+    const limb_t *xx;
+    limb_t *rr;
+
+    // Multiply the lowest limb of y by x.
+    carry = 0;
+    word = pgm_read_limb(&(y[0]));
+    xx = x;
+    rr = result;
+    for (i = 0; i < xcount; ++i) {
+        carry += ((dlimb_t)(*xx++)) * word;
+        *rr++ = (limb_t)carry;
+        carry >>= LIMB_BITS;
+    }
+    *rr = (limb_t)carry;
+
+    // Multiply and add the remaining limb of y by x.
+    for (i = 1; i < ycount; ++i) {
+        word = pgm_read_limb(&(y[i]));
+        carry = 0;
+        xx = x;
+        rr = result + i;
+        for (j = 0; j < xcount; ++j) {
+            carry += ((dlimb_t)(*xx++)) * word;
+            carry += *rr;
+            *rr++ = (limb_t)carry;
+            carry >>= LIMB_BITS;
+        }
+        *rr = (limb_t)carry;
+    }
+}
+
+/**
+ * \brief Reduces \a x modulo \a y using subtraction where \a y is
+ * in program memory.
+ *
+ * \param result The result of the reduction.  This can be the
+ * same as \a x.
+ * \param x The number to be reduced.
+ * \param y The base to use for the modulo reduction.  This must point
+ * into program memory.
+ * \param size The size of the values in limbs.
+ *
+ * It is assumed that \a x is less than \a y * 2 so that a single
+ * conditional subtraction will bring it down below \a y.  The reduction
+ * is performed in constant time.
+ *
+ * \sa reduceQuick()
+ */
+void BigNumberUtil::reduceQuick_P(limb_t *result, const limb_t *x,
+                                  const limb_t *y, size_t size)
+{
+    // Subtract "y" from "x" and turn the borrow into an AND mask.
+    limb_t mask = sub_P(result, x, y, size);
+    mask = (~mask) + 1;
+
+    // Add "y" back to the result if the mask is non-zero.
+    dlimb_t carry = 0;
+    while (size > 0) {
+        carry += *result;
+        carry += (pgm_read_limb(y++) & mask);
+        *result++ = (limb_t)carry;
+        carry >>= LIMB_BITS;
+        --size;
+    }
+}
+
+/**
+ * \brief Determine if a big number is zero.
+ *
+ * \param x Points to the number to test.
+ * \param size The number of limbs in \a x.
+ * \return Returns 1 if \a x is zero or 0 otherwise.
+ *
+ * This function attempts to make the determination in constant time.
+ */
+limb_t BigNumberUtil::isZero(const limb_t *x, size_t size)
+{
+    limb_t word = 0;
+    while (size > 0) {
+        word |= *x++;
+        --size;
+    }
+    return (limb_t)(((((dlimb_t)1) << LIMB_BITS) - word) >> LIMB_BITS);
+}

--- a/firmware/lib/Crypto/BigNumberUtil.h
+++ b/firmware/lib/Crypto/BigNumberUtil.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CRYPTO_BIGNUMBERUTIL_h
+#define CRYPTO_BIGNUMBERUTIL_h
+
+#include <inttypes.h>
+#include <stddef.h>
+
+// Define exactly one of these to 1 to set the size of the basic limb type.
+#if defined(__AVR__) || defined(ESP8266)
+// 16-bit limbs seem to give the best performance on 8-bit AVR micros.
+// They also seem to give better performance on ESP8266 as well.
+#define BIGNUMBER_LIMB_8BIT  0
+#define BIGNUMBER_LIMB_16BIT 1
+#define BIGNUMBER_LIMB_32BIT 0
+#define BIGNUMBER_LIMB_64BIT 0
+#elif defined(__GNUC__) && __WORDSIZE == 64
+// 64-bit system with 128-bit double limbs.
+#define BIGNUMBER_LIMB_8BIT  0
+#define BIGNUMBER_LIMB_16BIT 0
+#define BIGNUMBER_LIMB_32BIT 0
+#define BIGNUMBER_LIMB_64BIT 1
+#else
+// On all other platforms, assume 32-bit is best.
+#define BIGNUMBER_LIMB_8BIT  0
+#define BIGNUMBER_LIMB_16BIT 0
+#define BIGNUMBER_LIMB_32BIT 1
+#define BIGNUMBER_LIMB_64BIT 0
+#endif
+
+// Define the limb types to use on this platform.
+#if BIGNUMBER_LIMB_8BIT
+typedef uint8_t limb_t;
+typedef int8_t slimb_t;
+typedef uint16_t dlimb_t;
+#elif BIGNUMBER_LIMB_16BIT
+typedef uint16_t limb_t;
+typedef int16_t slimb_t;
+typedef uint32_t dlimb_t;
+#elif BIGNUMBER_LIMB_32BIT
+typedef uint32_t limb_t;
+typedef int32_t slimb_t;
+typedef uint64_t dlimb_t;
+#elif BIGNUMBER_LIMB_64BIT
+typedef uint64_t limb_t;
+typedef int64_t slimb_t;
+typedef unsigned __int128 dlimb_t;
+#else
+#error "limb_t must be 8, 16, 32, or 64 bits in size"
+#endif
+
+class BigNumberUtil
+{
+public:
+    static void unpackLE(limb_t *limbs, size_t count,
+                         const uint8_t *bytes, size_t len);
+    static void unpackBE(limb_t *limbs, size_t count,
+                         const uint8_t *bytes, size_t len);
+    static void packLE(uint8_t *bytes, size_t len,
+                       const limb_t *limbs, size_t count);
+    static void packBE(uint8_t *bytes, size_t len,
+                       const limb_t *limbs, size_t count);
+
+    static limb_t add(limb_t *result, const limb_t *x,
+                      const limb_t *y, size_t size);
+    static limb_t sub(limb_t *result, const limb_t *x,
+                      const limb_t *y, size_t size);
+    static void mul(limb_t *result, const limb_t *x, size_t xcount,
+                    const limb_t *y, size_t ycount);
+    static void reduceQuick(limb_t *result, const limb_t *x,
+                            const limb_t *y, size_t size);
+
+    static limb_t add_P(limb_t *result, const limb_t *x,
+                        const limb_t *y, size_t size);
+    static limb_t sub_P(limb_t *result, const limb_t *x,
+                        const limb_t *y, size_t size);
+    static void mul_P(limb_t *result, const limb_t *x, size_t xcount,
+                      const limb_t *y, size_t ycount);
+    static void reduceQuick_P(limb_t *result, const limb_t *x,
+                              const limb_t *y, size_t size);
+
+    static limb_t isZero(const limb_t *x, size_t size);
+
+private:
+    // Constructor and destructor are private - cannot instantiate this class.
+    BigNumberUtil() {}
+    ~BigNumberUtil() {}
+};
+
+#endif

--- a/firmware/lib/Crypto/ChaCha.cpp
+++ b/firmware/lib/Crypto/ChaCha.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "ChaCha.h"
+#include "Crypto.h"
+#include "utility/RotateUtil.h"
+#include "utility/EndianUtil.h"
+#include "utility/ProgMemUtil.h"
+#include <string.h>
+
+/**
+ * \class ChaCha ChaCha.h <ChaCha.h>
+ * \brief ChaCha stream cipher.
+ *
+ * ChaCha is a stream cipher that takes a key, an 8-byte nonce/IV, and a
+ * counter and hashes them to generate a keystream to XOR with the plaintext.
+ * Variations on the ChaCha cipher use 8, 12, or 20 rounds of hashing
+ * operations with either 128-bit or 256-bit keys.
+ *
+ * Reference: http://cr.yp.to/chacha.html
+ */
+
+/**
+ * \brief Constructs a new ChaCha stream cipher.
+ *
+ * \param numRounds Number of encryption rounds to use; usually 8, 12, or 20.
+ */
+ChaCha::ChaCha(uint8_t numRounds)
+    : rounds(numRounds)
+    , posn(64)
+{
+}
+
+ChaCha::~ChaCha()
+{
+    clean(block);
+    clean(stream);
+}
+
+size_t ChaCha::keySize() const
+{
+    // Default key size is 256-bit, but any key size is allowed.
+    return 32;
+}
+
+size_t ChaCha::ivSize() const
+{
+    // We return 8 but we also support 12-byte nonces in setIV().
+    return 8;
+}
+
+/**
+ * \fn uint8_t ChaCha::numRounds() const
+ * \brief Returns the number of encryption rounds; usually 8, 12, or 20.
+ *
+ * \sa setNumRounds()
+ */
+
+/**
+ * \fn void ChaCha::setNumRounds(uint8_t numRounds)
+ * \brief Sets the number of encryption rounds.
+ *
+ * \param numRounds The number of encryption rounds; usually 8, 12, or 20.
+ *
+ * \sa numRounds()
+ */
+
+bool ChaCha::setKey(const uint8_t *key, size_t len)
+{
+    static const char tag128[] PROGMEM = "expand 16-byte k";
+    static const char tag256[] PROGMEM = "expand 32-byte k";
+    if (len <= 16) {
+        memcpy_P(block, tag128, 16);
+        memcpy(block + 16, key, len);
+        memcpy(block + 32, key, len);
+        if (len < 16) {
+            memset(block + 16 + len, 0, 16 - len);
+            memset(block + 32 + len, 0, 16 - len);
+        }
+    } else {
+        if (len > 32)
+            len = 32;
+        memcpy_P(block, tag256, 16);
+        memcpy(block + 16, key, len);
+        if (len < 32)
+            memset(block + 16 + len, 0, 32 - len);
+    }
+    posn = 64;
+    return true;
+}
+
+bool ChaCha::setIV(const uint8_t *iv, size_t len)
+{
+    // From draft-nir-cfrg-chacha20-poly1305-10.txt, we can use either
+    // 64-bit or 96-bit nonces.  The 96-bit nonce consists of the high
+    // word of the counter prepended to a regular 64-bit nonce for ChaCha.
+    if (len == 8) {
+        memset(block + 48, 0, 8);
+        memcpy(block + 56, iv, len);
+        posn = 64;
+        return true;
+    } else if (len == 12) {
+        memset(block + 48, 0, 4);
+        memcpy(block + 52, iv, len);
+        posn = 64;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/**
+ * \brief Sets the starting counter for encryption.
+ *
+ * \param counter A 4-byte or 8-byte value to use for the starting counter
+ * instead of the default value of zero.
+ * \param len The length of the counter, which must be 4 or 8.
+ * \return Returns false if \a len is not 4 or 8.
+ *
+ * This function must be called after setIV() and before the first call
+ * to encrypt().  It is used to specify a different starting value than
+ * zero for the counter portion of the hash input.
+ *
+ * \sa setIV()
+ */
+bool ChaCha::setCounter(const uint8_t *counter, size_t len)
+{
+    // Normally both the IV and the counter are 8 bytes in length.
+    // However, if the IV was 12 bytes, then a 4 byte counter can be used.
+    if (len == 4 || len == 8) {
+        memcpy(block + 48, counter, len);
+        posn = 64;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+void ChaCha::encrypt(uint8_t *output, const uint8_t *input, size_t len)
+{
+    while (len > 0) {
+        if (posn >= 64) {
+            // Generate a new encrypted counter block.
+            hashCore((uint32_t *)stream, (const uint32_t *)block, rounds);
+            posn = 0;
+
+            // Increment the counter, taking care not to reveal
+            // any timing information about the starting value.
+            // We iterate through the entire counter region even
+            // if we could stop earlier because a byte is non-zero.
+            uint16_t temp = 1;
+            uint8_t index = 48;
+            while (index < 56) {
+                temp += block[index];
+                block[index] = (uint8_t)temp;
+                temp >>= 8;
+                ++index;
+            }
+        }
+        uint8_t templen = 64 - posn;
+        if (templen > len)
+            templen = len;
+        len -= templen;
+        while (templen > 0) {
+            *output++ = *input++ ^ stream[posn++];
+            --templen;
+        }
+    }
+}
+
+void ChaCha::decrypt(uint8_t *output, const uint8_t *input, size_t len)
+{
+    encrypt(output, input, len);
+}
+
+/**
+ * \brief Generates a single block of output direct from the keystream.
+ *
+ * \param output The output buffer to fill with keystream bytes.
+ *
+ * Unlike encrypt(), this function does not XOR the keystream with
+ * plaintext data.  Instead it generates the keystream directly into
+ * the caller-supplied buffer.  This is useful if the caller knows
+ * that the plaintext is all-zeroes.
+ *
+ * \sa encrypt()
+ */
+void ChaCha::keystreamBlock(uint32_t *output)
+{
+    // Generate the hash output directly into the caller-supplied buffer.
+    hashCore(output, (const uint32_t *)block, rounds);
+    posn = 64;
+
+    // Increment the lowest counter byte.  We are assuming that the caller
+    // is ChaChaPoly::setKey() and that the previous counter value was zero.
+    block[48] = 1;
+}
+
+void ChaCha::clear()
+{
+    clean(block);
+    clean(stream);
+    posn = 64;
+}
+
+// Perform a ChaCha quarter round operation.
+#define quarterRound(a, b, c, d)    \
+    do { \
+        uint32_t _b = (b); \
+        uint32_t _a = (a) + _b; \
+        uint32_t _d = leftRotate((d) ^ _a, 16); \
+        uint32_t _c = (c) + _d; \
+        _b = leftRotate12(_b ^ _c); \
+        _a += _b; \
+        (d) = _d = leftRotate(_d ^ _a, 8); \
+        _c += _d; \
+        (a) = _a; \
+        (b) = leftRotate7(_b ^ _c); \
+        (c) = _c; \
+    } while (0)
+
+/**
+ * \brief Executes the ChaCha hash core on an input memory block.
+ *
+ * \param output Output memory block, must be at least 16 words in length
+ * and must not overlap with \a input.
+ * \param input Input memory block, must be at least 16 words in length.
+ * \param rounds Number of ChaCha rounds to perform; usually 8, 12, or 20.
+ *
+ * This function is provided for the convenience of applications that need
+ * access to the ChaCha hash core without the higher-level processing that
+ * turns the core into a stream cipher.
+ */
+void ChaCha::hashCore(uint32_t *output, const uint32_t *input, uint8_t rounds)
+{
+    uint8_t posn;
+
+    // Copy the input buffer to the output prior to the first round
+    // and convert from little-endian to host byte order.
+    for (posn = 0; posn < 16; ++posn)
+        output[posn] = le32toh(input[posn]);
+
+    // Perform the ChaCha rounds in sets of two.
+    for (; rounds >= 2; rounds -= 2) {
+        // Column round.
+        quarterRound(output[0], output[4], output[8],  output[12]);
+        quarterRound(output[1], output[5], output[9],  output[13]);
+        quarterRound(output[2], output[6], output[10], output[14]);
+        quarterRound(output[3], output[7], output[11], output[15]);
+
+        // Diagonal round.
+        quarterRound(output[0], output[5], output[10], output[15]);
+        quarterRound(output[1], output[6], output[11], output[12]);
+        quarterRound(output[2], output[7], output[8],  output[13]);
+        quarterRound(output[3], output[4], output[9],  output[14]);
+    }
+
+    // Add the original input to the final output, convert back to
+    // little-endian, and return the result.
+    for (posn = 0; posn < 16; ++posn)
+        output[posn] = htole32(output[posn] + le32toh(input[posn]));
+}

--- a/firmware/lib/Crypto/ChaCha.h
+++ b/firmware/lib/Crypto/ChaCha.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CRYPTO_CHACHA_h
+#define CRYPTO_CHACHA_h
+
+#include "Cipher.h"
+
+class ChaChaPoly;
+
+class ChaCha : public Cipher
+{
+public:
+    explicit ChaCha(uint8_t numRounds = 20);
+    virtual ~ChaCha();
+
+    size_t keySize() const;
+    size_t ivSize() const;
+
+    uint8_t numRounds() const { return rounds; }
+    void setNumRounds(uint8_t numRounds) { rounds = numRounds; }
+
+    bool setKey(const uint8_t *key, size_t len);
+    bool setIV(const uint8_t *iv, size_t len);
+    bool setCounter(const uint8_t *counter, size_t len);
+
+    void encrypt(uint8_t *output, const uint8_t *input, size_t len);
+    void decrypt(uint8_t *output, const uint8_t *input, size_t len);
+
+    void clear();
+
+    static void hashCore(uint32_t *output, const uint32_t *input, uint8_t rounds);
+
+private:
+    uint8_t block[64];
+    uint8_t stream[64];
+    uint8_t rounds;
+    uint8_t posn;
+
+    void keystreamBlock(uint32_t *output);
+
+    friend class ChaChaPoly;
+};
+
+#endif

--- a/firmware/lib/Crypto/ChaChaPoly.cpp
+++ b/firmware/lib/Crypto/ChaChaPoly.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "ChaChaPoly.h"
+#include "Crypto.h"
+#include "utility/EndianUtil.h"
+#include <string.h>
+
+/**
+ * \class ChaChaPoly ChaChaPoly.h <ChaChaPoly.h>
+ * \brief Authenticated cipher based on ChaCha and Poly1305
+ *
+ * ChaChaPoly is an authenticated cipher based on a combination of
+ * ChaCha with 20 rounds for encryption and Poly1305 for authentication.
+ * The resulting cipher has a 256-bit key, a 64-bit or 96-bit
+ * initialization vector, and a 128-bit authentication tag.
+ *
+ * Reference: https://tools.ietf.org/html/draft-irtf-cfrg-chacha20-poly1305-10
+ *
+ * \sa ChaCha, Poly1305, AuthenticatedCipher
+ */
+
+/**
+ * \brief Constructs a new ChaChaPoly authenticated cipher.
+ */
+ChaChaPoly::ChaChaPoly()
+{
+    state.authSize = 0;
+    state.dataSize = 0;
+    state.dataStarted = false;
+    state.ivSize = 8;
+}
+
+/**
+ * \brief Destroys this ChaChaPoly authenticated cipher.
+ */
+ChaChaPoly::~ChaChaPoly()
+{
+    clean(state);
+}
+
+size_t ChaChaPoly::keySize() const
+{
+    // Default key size is 256-bit, but any key size is allowed.
+    return 32;
+}
+
+size_t ChaChaPoly::ivSize() const
+{
+    // Return 8 but we also support 12-byte nonces in setIV().
+    return 8;
+}
+
+size_t ChaChaPoly::tagSize() const
+{
+    // Any tag size between 1 and 16 is supported.
+    return 16;
+}
+
+bool ChaChaPoly::setKey(const uint8_t *key, size_t len)
+{
+    return chacha.setKey(key, len);
+}
+
+bool ChaChaPoly::setIV(const uint8_t *iv, size_t len)
+{
+    // ChaCha::setIV() supports both 64-bit and 96-bit nonces.
+    if (!chacha.setIV(iv, len))
+        return false;
+
+    // Generate the key and nonce to use for Poly1305.
+    uint32_t data[16];
+    chacha.keystreamBlock(data);
+    poly1305.reset(data);
+    memcpy(state.nonce, data + 4, 16);
+    clean(data);
+
+    // Reset the size counters for the auth data and payload.
+    state.authSize = 0;
+    state.dataSize = 0;
+    state.dataStarted = false;
+    state.ivSize = len;
+    return true;
+}
+
+void ChaChaPoly::encrypt(uint8_t *output, const uint8_t *input, size_t len)
+{
+    if (!state.dataStarted) {
+        poly1305.pad();
+        state.dataStarted = true;
+    }
+    chacha.encrypt(output, input, len);
+    poly1305.update(output, len);
+    state.dataSize += len;
+}
+
+void ChaChaPoly::decrypt(uint8_t *output, const uint8_t *input, size_t len)
+{
+    if (!state.dataStarted) {
+        poly1305.pad();
+        state.dataStarted = true;
+    }
+    poly1305.update(input, len);
+    chacha.encrypt(output, input, len); // encrypt() is the same as decrypt()
+    state.dataSize += len;
+}
+
+void ChaChaPoly::addAuthData(const void *data, size_t len)
+{
+    if (!state.dataStarted) {
+        poly1305.update(data, len);
+        state.authSize += len;
+    }
+}
+
+void ChaChaPoly::computeTag(void *tag, size_t len)
+{
+    uint64_t sizes[2];
+
+    // Pad the final Poly1305 block and then hash the sizes.
+    poly1305.pad();
+    sizes[0] = htole64(state.authSize);
+    sizes[1] = htole64(state.dataSize);
+    poly1305.update(sizes, sizeof(sizes));
+
+    // Compute the tag and copy it to the return buffer.
+    poly1305.finalize(state.nonce, tag, len);
+    clean(sizes);
+}
+
+bool ChaChaPoly::checkTag(const void *tag, size_t len)
+{
+    // Can never match if the expected tag length is too long.
+    if (len > 16)
+        return false;
+
+    // Compute the tag and check it.
+    uint8_t temp[16];
+    computeTag(temp, len);
+    bool equal = secure_compare(temp, tag, len);
+    clean(temp);
+    return equal;
+}
+
+void ChaChaPoly::clear()
+{
+    chacha.clear();
+    poly1305.clear();
+    clean(state);
+    state.ivSize = 8;
+}

--- a/firmware/lib/Crypto/ChaChaPoly.h
+++ b/firmware/lib/Crypto/ChaChaPoly.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CRYPTO_CHACHAPOLY_H
+#define CRYPTO_CHACHAPOLY_H
+
+#include "AuthenticatedCipher.h"
+#include "ChaCha.h"
+#include "Poly1305.h"
+
+class ChaChaPoly : public AuthenticatedCipher
+{
+public:
+    ChaChaPoly();
+    virtual ~ChaChaPoly();
+
+    size_t keySize() const;
+    size_t ivSize() const;
+    size_t tagSize() const;
+
+    bool setKey(const uint8_t *key, size_t len);
+    bool setIV(const uint8_t *iv, size_t len);
+
+    void encrypt(uint8_t *output, const uint8_t *input, size_t len);
+    void decrypt(uint8_t *output, const uint8_t *input, size_t len);
+
+    void addAuthData(const void *data, size_t len);
+
+    void computeTag(void *tag, size_t len);
+    bool checkTag(const void *tag, size_t len);
+
+    void clear();
+
+private:
+    ChaCha chacha;
+    Poly1305 poly1305;
+    struct {
+        uint8_t nonce[16];
+        uint64_t authSize;
+        uint64_t dataSize;
+        bool dataStarted;
+        uint8_t ivSize;
+    } state;
+};
+
+#endif

--- a/firmware/lib/Crypto/Cipher.cpp
+++ b/firmware/lib/Crypto/Cipher.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "Cipher.h"
+
+/**
+ * \class Cipher Cipher.h <Cipher.h>
+ * \brief Abstract base class for stream ciphers.
+ *
+ * This class is intended for implementing ciphers that operate on arbitrary
+ * amounts of data.  In particular, stream ciphers where the number of
+ * bytes that are input to encrypt() or decrypt() is exactly the same as
+ * the number of bytes that are output.
+ *
+ * All of the stream ciphers such as ChaCha inherit directly from this class,
+ * together with block cipher modes such as CTR and CFB.
+ */
+
+/**
+ * \brief Constructs a new cipher object.
+ */
+Cipher::Cipher()
+{
+}
+
+/**
+ * \brief Destroys this cipher object.
+ *
+ * Subclasses are responsible for clearing temporary key schedules
+ * and other buffers so as to avoid leaking sensitive information.
+ *
+ * \sa clear()
+ */
+Cipher::~Cipher()
+{
+}
+
+/**
+ * \fn size_t Cipher::keySize() const
+ * \brief Default size of the key for this cipher, in bytes.
+ *
+ * If the cipher supports variable-sized keys, keySize() indicates the
+ * default or recommended key size.  The cipher may support other key sizes.
+ *
+ * \sa setKey(), ivSize()
+ */
+
+/**
+ * \fn size_t Cipher::ivSize() const
+ * \brief Size of the initialization vector for this cipher, in bytes.
+ *
+ * If the cipher does not need an initialization vector, this function
+ * will return zero.
+ */
+
+/**
+ * \fn bool Cipher::setKey(const uint8_t *key, size_t len)
+ * \brief Sets the key to use for future encryption and decryption operations.
+ *
+ * \param key The key to use.
+ * \param len The length of the key in bytes.
+ * \return Returns false if the key length is not supported, or the key
+ * is somehow "weak" and unusable by this cipher.
+ *
+ * Use clear() or the destructor to remove the key and any other sensitive
+ * data from the object once encryption or decryption is complete.
+ *
+ * Calling setKey() resets the cipher.  Any temporary data that was being
+ * retained for encrypting partial blocks will be abandoned.
+ *
+ * \sa keySize(), clear()
+ */
+
+/**
+ * \fn bool Cipher::setIV(const uint8_t *iv, size_t len)
+ * \brief Sets the initialization vector to use for future encryption and
+ * decryption operations.
+ *
+ * \param iv The initialization vector to use.
+ * \param len The length of the initialization vector in bytes.
+ * \return Returns false if the length is not supported.
+ *
+ * Initialization vectors should be set before the first call to
+ * encrypt() or decrypt() after a setKey() call.  If the initialization
+ * vector is changed after encryption or decryption begins,
+ * then the behaviour is undefined.
+ *
+ * \note The IV is not encoded into the output stream by encrypt().
+ * The caller is responsible for communicating the IV to the other party.
+ *
+ * \sa ivSize()
+ */
+
+/**
+ * \fn void Cipher::encrypt(uint8_t *output, const uint8_t *input, size_t len)
+ * \brief Encrypts an input buffer and writes the ciphertext to an
+ * output buffer.
+ *
+ * \param output The output buffer to write to, which may be the same
+ * buffer as \a input.  The \a output buffer must have at least as many
+ * bytes as the \a input buffer.
+ * \param input The input buffer to read from.
+ * \param len The number of bytes to encrypt.
+ *
+ * The encrypt() function can be called multiple times with different
+ * regions of the plaintext data.
+ *
+ * \sa decrypt()
+ */
+
+/**
+ * \fn void Cipher::decrypt(uint8_t *output, const uint8_t *input, size_t len)
+ * \brief Decrypts an input buffer and writes the plaintext to an
+ * output buffer.
+ *
+ * \param output The output buffer to write to, which may be the same
+ * buffer as \a input.  The \a output buffer must have at least as many
+ * bytes as the \a input buffer.
+ * \param input The input buffer to read from.
+ * \param len The number of bytes to decrypt.
+ *
+ * The decrypt() function can be called multiple times with different
+ * regions of the ciphertext data.
+ *
+ * \sa encrypt()
+ */
+
+/**
+ * \fn void Cipher::clear()
+ * \brief Clears all security-sensitive state from this cipher.
+ *
+ * Security-sensitive information includes key schedules, initialization
+ * vectors, and any temporary state that is used by encrypt() or decrypt()
+ * which is stored in the cipher itself.
+ */

--- a/firmware/lib/Crypto/Cipher.h
+++ b/firmware/lib/Crypto/Cipher.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CRYPTO_CIPHER_h
+#define CRYPTO_CIPHER_h
+
+#include <inttypes.h>
+#include <stddef.h>
+
+class Cipher
+{
+public:
+    Cipher();
+    virtual ~Cipher();
+
+    virtual size_t keySize() const = 0;
+    virtual size_t ivSize() const = 0;
+
+    virtual bool setKey(const uint8_t *key, size_t len) = 0;
+    virtual bool setIV(const uint8_t *iv, size_t len) = 0;
+
+    virtual void encrypt(uint8_t *output, const uint8_t *input, size_t len) = 0;
+    virtual void decrypt(uint8_t *output, const uint8_t *input, size_t len) = 0;
+
+    virtual void clear() = 0;
+};
+
+#endif

--- a/firmware/lib/Crypto/Crypto.cpp
+++ b/firmware/lib/Crypto/Crypto.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "Crypto.h"
+
+/**
+ * \brief Cleans a block of bytes.
+ *
+ * \param dest The destination block to be cleaned.
+ * \param size The size of the destination to be cleaned in bytes.
+ *
+ * Unlike memset(), this function attempts to prevent the compiler
+ * from optimizing away the clear on a memory buffer.
+ */
+void clean(void *dest, size_t size)
+{
+    // Force the use of volatile so that we actually clear the memory.
+    // Otherwise the compiler might optimise the entire contents of this
+    // function away, which will not be secure.
+    volatile uint8_t *d = (volatile uint8_t *)dest;
+    while (size > 0) {
+        *d++ = 0;
+        --size;
+    }
+}
+
+/**
+ * \fn void clean(T &var)
+ * \brief Template function that cleans a variable.
+ *
+ * \param var A reference to the variable to clean.
+ *
+ * The variable will be cleared to all-zeroes in a secure manner.
+ * Unlike memset(), this function attempts to prevent the compiler
+ * from optimizing away the variable clear.
+ */
+
+/**
+ * \brief Compares two memory blocks for equality.
+ *
+ * \param data1 Points to the first memory block.
+ * \param data2 Points to the second memory block.
+ * \param len The size of the memory blocks in bytes.
+ *
+ * Unlike memcmp(), this function attempts to compare the two memory blocks
+ * in a way that will not reveal the contents in the instruction timing.
+ * In particular, this function will not stop early if a byte is different.
+ * It will instead continue onto the end of the array.
+ */
+bool secure_compare(const void *data1, const void *data2, size_t len)
+{
+    uint8_t result = 0;
+    const uint8_t *d1 = (const uint8_t *)data1;
+    const uint8_t *d2 = (const uint8_t *)data2;
+    while (len > 0) {
+        result |= (*d1++ ^ *d2++);
+        --len;
+    }
+    return (bool)((((uint16_t)0x0100) - result) >> 8);
+}
+
+/**
+ * \brief Calculates the CRC-8 value over an array in memory.
+ *
+ * \param tag Starting tag to distinguish this calculation.
+ * \param data The data to checksum.
+ * \param size The number of bytes to checksum.
+ * \return The CRC-8 value over the data.
+ *
+ * This function does not provide any real security.  It is a simple
+ * check that seed values have been initialized within EEPROM or Flash.
+ * If the CRC-8 check fails, then it is assumed that the EEPROM/Flash
+ * contents are invalid and should be re-initialized.
+ *
+ * Reference: http://www.sunshine2k.de/articles/coding/crc/understanding_crc.html#ch4
+ */
+uint8_t crypto_crc8(uint8_t tag, const void *data, unsigned size)
+{
+    const uint8_t *d = (const uint8_t *)data;
+    uint8_t crc = 0xFF ^ tag;
+    uint8_t bit;
+    while (size > 0) {
+        crc ^= *d++;
+        for (bit = 0; bit < 8; ++bit) {
+            // if (crc & 0x80)
+            //     crc = (crc << 1) ^ 0x1D;
+            // else
+            //     crc = (crc << 1);
+            uint8_t generator = (uint8_t)((((int8_t)crc) >> 7) & 0x1D);
+            crc = (crc << 1) ^ generator;
+        }
+        --size;
+    }
+    return crc;
+}

--- a/firmware/lib/Crypto/Crypto.h
+++ b/firmware/lib/Crypto/Crypto.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CRYPTO_h
+#define CRYPTO_h
+
+#include <inttypes.h>
+#include <stddef.h>
+
+void clean(void *dest, size_t size);
+
+template <typename T>
+inline void clean(T &var)
+{
+    clean(&var, sizeof(T));
+}
+
+bool secure_compare(const void *data1, const void *data2, size_t len);
+
+#if defined(ESP8266)
+extern "C" void system_soft_wdt_feed(void);
+#define crypto_feed_watchdog() system_soft_wdt_feed()
+#else
+#define crypto_feed_watchdog() do { ; } while (0)
+#endif
+
+#endif

--- a/firmware/lib/Crypto/Hash.cpp
+++ b/firmware/lib/Crypto/Hash.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "Hash.h"
+#include <string.h>
+
+/**
+ * \class Hash Hash.h <Hash.h>
+ * \brief Abstract base class for cryptographic hash algorithms.
+ *
+ * \sa SHA224, SHA256, SHA384, SHA3_256, BLAKE2s
+ */
+
+/**
+ * \brief Constructs a new hash object.
+ */
+Hash::Hash()
+{
+}
+
+/**
+ * \brief Destroys this hash object.
+ *
+ * \note Subclasses are responsible for clearing any sensitive data
+ * that remains in the hash object when it is destroyed.
+ *
+ * \sa clear()
+ */
+Hash::~Hash()
+{
+}
+
+/**
+ * \fn size_t Hash::hashSize() const
+ * \brief Size of the hash result from finalize().
+ *
+ * \sa finalize(), blockSize()
+ */
+
+/**
+ * \fn size_t Hash::blockSize() const
+ * \brief Size of the internal block used by the hash algorithm.
+ *
+ * \sa update(), hashSize()
+ */
+
+/**
+ * \fn void Hash::reset()
+ * \brief Resets the hash ready for a new hashing process.
+ *
+ * \sa update(), finalize(), resetHMAC()
+ */
+
+/**
+ * \fn void Hash::update(const void *data, size_t len)
+ * \brief Updates the hash with more data.
+ *
+ * \param data Data to be hashed.
+ * \param len Number of bytes of data to be hashed.
+ *
+ * If finalize() has already been called, then the behavior of update() will
+ * be undefined.  Call reset() first to start a new hashing process.
+ *
+ * \sa reset(), finalize()
+ */
+
+/**
+ * \fn void Hash::finalize(void *hash, size_t len)
+ * \brief Finalizes the hashing process and returns the hash.
+ *
+ * \param hash The buffer to return the hash value in.
+ * \param len The length of the \a hash buffer, normally hashSize().
+ *
+ * If \a len is less than hashSize(), then the hash value will be
+ * truncated to the first \a len bytes.  If \a len is greater than
+ * hashSize(), then the remaining bytes will left unchanged.
+ *
+ * If finalize() is called again, then the returned \a hash value is
+ * undefined.  Call reset() first to start a new hashing process.
+ *
+ * \sa reset(), update(), finalizeHMAC()
+ */
+
+/**
+ * \fn void Hash::clear()
+ * \brief Clears the hash state, removing all sensitive data, and then
+ * resets the hash ready for a new hashing process.
+ *
+ * \sa reset()
+ */
+
+/**
+ * \fn void Hash::resetHMAC(const void *key, size_t keyLen)
+ * \brief Resets the hash ready for a new HMAC hashing process.
+ *
+ * \param key Points to the HMAC key for the hashing process.
+ * \param keyLen Size of the HMAC \a key in bytes.
+ *
+ * The following example computes a HMAC over a series of data blocks
+ * with a specific key:
+ *
+ * \code
+ * hash.resetHMAC(key, sizeof(key));
+ * hash.update(data1, sizeof(data1));
+ * hash.update(data2, sizeof(data2));
+ * ...
+ * hash.update(dataN, sizeof(dataN));
+ * hash.finalizeHMAC(key, sizeof(key), hmac, sizeof(hmac));
+ * \endcode
+ *
+ * The same key must be passed to both resetHMAC() and finalizeHMAC().
+ *
+ * \sa finalizeHMAC(), reset()
+ */
+
+/**
+ * \fn void Hash::finalizeHMAC(const void *key, size_t keyLen, void *hash, size_t hashLen)
+ * \brief Finalizes the HMAC hashing process and returns the hash.
+ *
+ * \param key Points to the HMAC key for the hashing process.  The contents
+ * of this array must be identical to the value passed to resetHMAC().
+ * \param keyLen Size of the HMAC \a key in bytes.
+ * \param hash The buffer to return the hash value in.
+ * \param hashLen The length of the \a hash buffer, normally hashSize().
+ *
+ * \sa resetHMAC(), finalize()
+ */
+
+/**
+ * \brief Formats a HMAC key into a block.
+ *
+ * \param block The block to format the key into.  Must be at least
+ * blockSize() bytes in length.
+ * \param key Points to the HMAC key for the hashing process.
+ * \param len Length of the HMAC \a key in bytes.
+ * \param pad Inner (0x36) or outer (0x5C) padding value to XOR with
+ * the formatted HMAC key.
+ *
+ * This function is intended to help subclasses implement resetHMAC() and
+ * finalizeHMAC() by directly formatting the HMAC key into the subclass's
+ * internal block buffer and resetting the hash.
+ */
+void Hash::formatHMACKey(void *block, const void *key, size_t len, uint8_t pad)
+{
+    size_t size = blockSize();
+    reset();
+    if (len <= size) {
+        memcpy(block, key, len);
+    } else {
+        update(key, len);
+        len = hashSize();
+        finalize(block, len);
+        reset();
+    }
+    uint8_t *b = (uint8_t *)block;
+    memset(b + len, pad, size - len);
+    while (len > 0) {
+        *b++ ^= pad;
+        --len;
+    }
+}

--- a/firmware/lib/Crypto/Hash.h
+++ b/firmware/lib/Crypto/Hash.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CRYPTO_HASH_h
+#define CRYPTO_HASH_h
+
+#include <inttypes.h>
+#include <stddef.h>
+
+class Hash
+{
+public:
+    Hash();
+    virtual ~Hash();
+
+    virtual size_t hashSize() const = 0;
+    virtual size_t blockSize() const = 0;
+
+    virtual void reset() = 0;
+    virtual void update(const void *data, size_t len) = 0;
+    virtual void finalize(void *hash, size_t len) = 0;
+
+    virtual void clear() = 0;
+
+    virtual void resetHMAC(const void *key, size_t keyLen) = 0;
+    virtual void finalizeHMAC(const void *key, size_t keyLen, void *hash, size_t hashLen) = 0;
+
+protected:
+    void formatHMACKey(void *block, const void *key, size_t len, uint8_t pad);
+};
+
+#endif

--- a/firmware/lib/Crypto/Poly1305.cpp
+++ b/firmware/lib/Crypto/Poly1305.cpp
@@ -1,0 +1,345 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "Poly1305.h"
+#include "Crypto.h"
+#include "utility/EndianUtil.h"
+#include "utility/LimbUtil.h"
+#include <string.h>
+
+/**
+ * \class Poly1305 Poly1305.h <Poly1305.h>
+ * \brief Poly1305 message authenticator
+ *
+ * Poly1305 is a message authenticator designed by Daniel J. Bernstein.
+ * An arbitrary-length message is broken up into 16-byte chunks and fed
+ * into a polynomial mod 2<sup>130</sup> - 5 based on the 16-byte
+ * authentication key.  The final polynomial value is then combined with a
+ * 16-byte nonce to create the authentication token.
+ *
+ * The following example demonstrates how to compute an authentication token
+ * for a message made up of several blocks under a specific key and nonce:
+ *
+ * \code
+ * Poly1305 poly1305;
+ * uint8_t token[16];
+ * poly1305.reset(key);
+ * poly1305.update(block1, sizeof(block1));
+ * poly1305.update(block2, sizeof(block2));
+ * ...
+ * poly1305.update(blockN, sizeof(blockN));
+ * poly1305.finalize(nonce, token, sizeof(token));
+ * \endcode
+ *
+ * In the original Poly1305 specification, the nonce was encrypted with AES
+ * and a second 16-byte key.  Since then, common practice has been for the
+ * caller to encrypt the nonce which gives the caller more flexibility as
+ * to how to derive and/or encrypt the nonce.
+ *
+ * References: http://en.wikipedia.org/wiki/Poly1305-AES,
+ * http://cr.yp.to/mac.html
+ */
+
+// Limb array with enough space for 130 bits.
+#define NUM_LIMBS_130BIT    (NUM_LIMBS_128BIT + 1)
+
+// Endian helper macros for limbs and arrays of limbs.
+#if BIGNUMBER_LIMB_8BIT
+#define lelimbtoh(x)        (x)
+#define htolelimb(x)        (x)
+#elif BIGNUMBER_LIMB_16BIT
+#define lelimbtoh(x)        (le16toh((x)))
+#define htolelimb(x)        (htole16((x)))
+#elif BIGNUMBER_LIMB_32BIT
+#define lelimbtoh(x)        (le32toh((x)))
+#define htolelimb(x)        (htole32((x)))
+#elif BIGNUMBER_LIMB_64BIT
+#define lelimbtoh(x)        (le64toh((x)))
+#define htolelimb(x)        (htole64((x)))
+#endif
+#if defined(CRYPTO_LITTLE_ENDIAN)
+#define littleToHost(r,size)    do { ; } while (0)
+#else
+#define littleToHost(r,size)   \
+    do { \
+        for (uint8_t i = 0; i < (size); ++i) \
+            (r)[i] = lelimbtoh((r)[i]); \
+    } while (0)
+#endif
+
+/**
+ * \brief Constructs a new Poly1305 message authenticator.
+ */
+Poly1305::Poly1305()
+{
+    state.chunkSize = 0;
+}
+
+/**
+ * \brief Destroys this Poly1305 message authenticator after clearing all
+ * sensitive information.
+ */
+Poly1305::~Poly1305()
+{
+    clean(state);
+}
+
+/**
+ * \brief Resets the Poly1305 message authenticator for a new session.
+ *
+ * \param key Points to the 16 byte authentication key.
+ *
+ * \sa update(), finalize()
+ */
+void Poly1305::reset(const void *key)
+{
+    // Copy the key into place and clear the bits we don't need.
+    uint8_t *r = (uint8_t *)state.r;
+    memcpy(r, key, 16);
+    r[3] &= 0x0F;
+    r[4] &= 0xFC;
+    r[7] &= 0x0F;
+    r[8] &= 0xFC;
+    r[11] &= 0x0F;
+    r[12] &= 0xFC;
+    r[15] &= 0x0F;
+
+    // Convert into little-endian if necessary.
+    littleToHost(state.r, NUM_LIMBS_128BIT);
+
+    // Reset the hashing process.
+    state.chunkSize = 0;
+    memset(state.h, 0, sizeof(state.h));
+}
+
+/**
+ * \brief Updates the message authenticator with more data.
+ *
+ * \param data Data to be hashed.
+ * \param len Number of bytes of data to be hashed.
+ *
+ * If finalize() has already been called, then the behavior of update() will
+ * be undefined.  Call reset() first to start a new authentication process.
+ *
+ * \sa pad(), reset(), finalize()
+ */
+void Poly1305::update(const void *data, size_t len)
+{
+    // Break the input up into 128-bit chunks and process each in turn.
+    const uint8_t *d = (const uint8_t *)data;
+    while (len > 0) {
+        uint8_t size = 16 - state.chunkSize;
+        if (size > len)
+            size = len;
+        memcpy(((uint8_t *)state.c) + state.chunkSize, d, size);
+        state.chunkSize += size;
+        len -= size;
+        d += size;
+        if (state.chunkSize == 16) {
+            littleToHost(state.c, NUM_LIMBS_128BIT);
+            state.c[NUM_LIMBS_128BIT] = 1;
+            processChunk();
+            state.chunkSize = 0;
+        }
+    }
+}
+
+/**
+ * \brief Finalizes the authentication process and returns the token.
+ *
+ * \param nonce Points to the 16-bit nonce to combine with the token.
+ * \param token The buffer to return the token value in.
+ * \param len The length of the \a token buffer between 0 and 16.
+ *
+ * If \a len is less than 16, then the token value will be truncated to
+ * the first \a len bytes.  If \a len is greater than 16, then the remaining
+ * bytes will left unchanged.
+ *
+ * If finalize() is called again, then the returned \a token value is
+ * undefined.  Call reset() first to start a new authentication process.
+ *
+ * \sa reset(), update()
+ */
+void Poly1305::finalize(const void *nonce, void *token, size_t len)
+{
+    dlimb_t carry;
+    uint8_t i;
+    limb_t t[NUM_LIMBS_256BIT + 1];
+
+    // Pad and flush the final chunk.
+    if (state.chunkSize > 0) {
+        uint8_t *c = (uint8_t *)state.c;
+        c[state.chunkSize] = 1;
+        memset(c + state.chunkSize + 1, 0, 16 - state.chunkSize - 1);
+        littleToHost(state.c, NUM_LIMBS_128BIT);
+        state.c[NUM_LIMBS_128BIT] = 0;
+        processChunk();
+    }
+
+    // At this point, processChunk() has left h as a partially reduced
+    // result that is less than (2^130 - 5) * 6.  Perform one more
+    // reduction and a trial subtraction to produce the final result.
+
+    // Multiply the high bits of h by 5 and add them to the 130 low bits.
+    carry = (dlimb_t)((state.h[NUM_LIMBS_128BIT] >> 2) +
+                      (state.h[NUM_LIMBS_128BIT] & ~((limb_t)3)));
+    state.h[NUM_LIMBS_128BIT] &= 0x0003;
+    for (i = 0; i < NUM_LIMBS_128BIT; ++i) {
+        carry += state.h[i];
+        state.h[i] = (limb_t)carry;
+        carry >>= LIMB_BITS;
+    }
+    state.h[i] += (limb_t)carry;
+
+    // Subtract (2^130 - 5) from h by computing t = h + 5 - 2^130.
+    // The "minus 2^130" step is implicit.
+    carry = 5;
+    for (i = 0; i < NUM_LIMBS_130BIT; ++i) {
+        carry += state.h[i];
+        t[i] = (limb_t)carry;
+        carry >>= LIMB_BITS;
+    }
+
+    // Borrow occurs if bit 2^130 of the previous t result is zero.
+    // Carefully turn this into a selection mask so we can select either
+    // h or t as the final result.  We don't care about the highest word
+    // of the result because we are about to drop it in the next step.
+    // We have to do it this way to avoid giving away any information
+    // about the value of h in the instruction timing.
+    limb_t mask = (~((t[NUM_LIMBS_128BIT] >> 2) & 1)) + 1;
+    limb_t nmask = ~mask;
+    for (i = 0; i < NUM_LIMBS_128BIT; ++i) {
+        state.h[i] = (state.h[i] & nmask) | (t[i] & mask);
+    }
+
+    // Add the encrypted nonce and format the final hash.
+    memcpy(state.c, nonce, 16);
+    littleToHost(state.c, NUM_LIMBS_128BIT);
+    carry = 0;
+    for (i = 0; i < NUM_LIMBS_128BIT; ++i) {
+        carry += state.h[i];
+        carry += state.c[i];
+        state.h[i] = htolelimb((limb_t)carry);
+        carry >>= LIMB_BITS;
+    }
+    if (len > 16)
+        len = 16;
+    memcpy(token, state.h, len);
+}
+
+/**
+ * \brief Pads the input stream with zero bytes to a multiple of 16.
+ *
+ * \sa update()
+ */
+void Poly1305::pad()
+{
+    if (state.chunkSize != 0) {
+        memset(((uint8_t *)state.c) + state.chunkSize, 0, 16 - state.chunkSize);
+        littleToHost(state.c, NUM_LIMBS_128BIT);
+        state.c[NUM_LIMBS_128BIT] = 1;
+        processChunk();
+        state.chunkSize = 0;
+    }
+}
+
+/**
+ * \brief Clears the authenticator's state, removing all sensitive data.
+ */
+void Poly1305::clear()
+{
+    clean(state);
+}
+
+/**
+ * \brief Processes a single 128-bit chunk of input data.
+ */
+void Poly1305::processChunk()
+{
+    limb_t t[NUM_LIMBS_256BIT + 1];
+
+    // Compute h = ((h + c) * r) mod (2^130 - 5).
+
+    // Start with h += c.  We assume that h is less than (2^130 - 5) * 6
+    // and that c is less than 2^129, so the result will be less than 2^133.
+    dlimb_t carry = 0;
+    uint8_t i, j;
+    for (i = 0; i < NUM_LIMBS_130BIT; ++i) {
+        carry += state.h[i];
+        carry += state.c[i];
+        state.h[i] = (limb_t)carry;
+        carry >>= LIMB_BITS;
+    }
+
+    // Multiply h by r.  We know that r is less than 2^124 because the
+    // top 4 bits were AND-ed off by reset().  That makes h * r less
+    // than 2^257.  Which is less than the (2^130 - 6)^2 we want for
+    // the modulo reduction step that follows.
+    carry = 0;
+    limb_t word = state.r[0];
+    for (i = 0; i < NUM_LIMBS_130BIT; ++i) {
+        carry += ((dlimb_t)(state.h[i])) * word;
+        t[i] = (limb_t)carry;
+        carry >>= LIMB_BITS;
+    }
+    t[NUM_LIMBS_130BIT] = (limb_t)carry;
+    for (i = 1; i < NUM_LIMBS_128BIT; ++i) {
+        word = state.r[i];
+        carry = 0;
+        for (j = 0; j < NUM_LIMBS_130BIT; ++j) {
+            carry += ((dlimb_t)(state.h[j])) * word;
+            carry += t[i + j];
+            t[i + j] = (limb_t)carry;
+            carry >>= LIMB_BITS;
+        }
+        t[i + NUM_LIMBS_130BIT] = (limb_t)carry;
+    }
+
+    // Reduce h * r modulo (2^130 - 5) by multiplying the high 130 bits by 5
+    // and adding them to the low 130 bits.  See the explaination in the
+    // comments for Curve25519::reduce() for a description of how this works.
+    carry = ((dlimb_t)(t[NUM_LIMBS_128BIT] >> 2)) +
+                      (t[NUM_LIMBS_128BIT] & ~((limb_t)3));
+    t[NUM_LIMBS_128BIT] &= 0x0003;
+    for (i = 0; i < NUM_LIMBS_128BIT; ++i) {
+        // Shift the next word of t up by (LIMB_BITS - 2) bits and then
+        // multiply it by 5.  Breaking it down, we can add the results
+        // of shifting up by LIMB_BITS and shifting up by (LIMB_BITS - 2).
+        // The main wrinkle here is that this can result in an intermediate
+        // carry that is (LIMB_BITS * 2 + 1) bits in size which doesn't
+        // fit within a dlimb_t variable.  However, we can defer adding
+        // (word << LIMB_BITS) until after the "carry >>= LIMB_BITS" step
+        // because it won't affect the low bits of the carry.
+        word = t[i + NUM_LIMBS_130BIT];
+        carry += ((dlimb_t)word) << (LIMB_BITS - 2);
+        carry += t[i];
+        state.h[i] = (limb_t)carry;
+        carry >>= LIMB_BITS;
+        carry += word;
+    }
+    state.h[i] = (limb_t)(carry + t[NUM_LIMBS_128BIT]);
+
+    // At this point, h is either the answer of reducing modulo (2^130 - 5)
+    // or it is at most 5 subtractions away from the answer we want.
+    // Leave it as-is for now with h less than (2^130 - 5) * 6.  It is
+    // still within a range where the next h * r step will not overflow.
+}

--- a/firmware/lib/Crypto/Poly1305.h
+++ b/firmware/lib/Crypto/Poly1305.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CRYPTO_POLY1305_h
+#define CRYPTO_POLY1305_h
+
+#include "BigNumberUtil.h"
+#include <stddef.h>
+
+class Poly1305
+{
+public:
+    Poly1305();
+    ~Poly1305();
+
+    void reset(const void *key);
+    void update(const void *data, size_t len);
+    void finalize(const void *nonce, void *token, size_t len);
+
+    void pad();
+
+    void clear();
+
+private:
+    struct {
+        limb_t h[(16 / sizeof(limb_t)) + 1];
+        limb_t c[(16 / sizeof(limb_t)) + 1];
+        limb_t r[(16 / sizeof(limb_t))];
+        uint8_t chunkSize;
+    } state;
+
+    void processChunk();
+};
+
+#endif

--- a/firmware/lib/Crypto/README.txt
+++ b/firmware/lib/Crypto/README.txt
@@ -1,0 +1,29 @@
+Files are from https://github.com/rweather/arduinolibs/tree/master/libraries/Crypto, commit 0a6acec.
+
+This library had to be vendored because the platformio provided version tries to #include "hwcrypto/aes.h"
+which doesn't work on the ESP32 & version 2 of the core. Also, this way we only get SHA256 and ChaCha20-Poly1305.
+
+License:
+
+/*
+ * Copyright (C) 2012 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+

--- a/firmware/lib/Crypto/SHA256.cpp
+++ b/firmware/lib/Crypto/SHA256.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "SHA256.h"
+#include "Crypto.h"
+#include "utility/RotateUtil.h"
+#include "utility/EndianUtil.h"
+#include "utility/ProgMemUtil.h"
+#include <string.h>
+
+/**
+ * \class SHA256 SHA256.h <SHA256.h>
+ * \brief SHA-256 hash algorithm.
+ *
+ * Reference: http://en.wikipedia.org/wiki/SHA-2
+ *
+ * \sa SHA224, SHA384, SHA512, SHA3_256, BLAKE2s
+ */
+
+/**
+ * \brief Constructs a SHA-256 hash object.
+ */
+SHA256::SHA256()
+{
+    reset();
+}
+
+/**
+ * \brief Destroys this SHA-256 hash object after clearing
+ * sensitive information.
+ */
+SHA256::~SHA256()
+{
+    clean(state);
+}
+
+size_t SHA256::hashSize() const
+{
+    return 32;
+}
+
+size_t SHA256::blockSize() const
+{
+    return 64;
+}
+
+void SHA256::reset()
+{
+    state.h[0] = 0x6a09e667;
+    state.h[1] = 0xbb67ae85;
+    state.h[2] = 0x3c6ef372;
+    state.h[3] = 0xa54ff53a,
+    state.h[4] = 0x510e527f;
+    state.h[5] = 0x9b05688c;
+    state.h[6] = 0x1f83d9ab;
+    state.h[7] = 0x5be0cd19;
+    state.chunkSize = 0;
+    state.length = 0;
+}
+
+void SHA256::update(const void *data, size_t len)
+{
+    // Update the total length (in bits, not bytes).
+    state.length += ((uint64_t)len) << 3;
+
+    // Break the input up into 512-bit chunks and process each in turn.
+    const uint8_t *d = (const uint8_t *)data;
+    while (len > 0) {
+        uint8_t size = 64 - state.chunkSize;
+        if (size > len)
+            size = len;
+        memcpy(((uint8_t *)state.w) + state.chunkSize, d, size);
+        state.chunkSize += size;
+        len -= size;
+        d += size;
+        if (state.chunkSize == 64) {
+            processChunk();
+            state.chunkSize = 0;
+        }
+    }
+}
+
+void SHA256::finalize(void *hash, size_t len)
+{
+    // Pad the last chunk.  We may need two padding chunks if there
+    // isn't enough room in the first for the padding and length.
+    uint8_t *wbytes = (uint8_t *)state.w;
+    if (state.chunkSize <= (64 - 9)) {
+        wbytes[state.chunkSize] = 0x80;
+        memset(wbytes + state.chunkSize + 1, 0x00, 64 - 8 - (state.chunkSize + 1));
+        state.w[14] = htobe32((uint32_t)(state.length >> 32));
+        state.w[15] = htobe32((uint32_t)state.length);
+        processChunk();
+    } else {
+        wbytes[state.chunkSize] = 0x80;
+        memset(wbytes + state.chunkSize + 1, 0x00, 64 - (state.chunkSize + 1));
+        processChunk();
+        memset(wbytes, 0x00, 64 - 8);
+        state.w[14] = htobe32((uint32_t)(state.length >> 32));
+        state.w[15] = htobe32((uint32_t)state.length);
+        processChunk();
+    }
+
+    // Convert the result into big endian and return it.
+    for (uint8_t posn = 0; posn < 8; ++posn)
+        state.w[posn] = htobe32(state.h[posn]);
+
+    // Copy the hash to the caller's return buffer.
+    size_t maxHashSize = hashSize();
+    if (len > maxHashSize)
+        len = maxHashSize;
+    memcpy(hash, state.w, len);
+}
+
+void SHA256::clear()
+{
+    clean(state);
+    reset();
+}
+
+void SHA256::resetHMAC(const void *key, size_t keyLen)
+{
+    formatHMACKey(state.w, key, keyLen, 0x36);
+    state.length += 64 * 8;
+    processChunk();
+}
+
+void SHA256::finalizeHMAC(const void *key, size_t keyLen, void *hash, size_t hashLen)
+{
+    uint8_t temp[32];
+    finalize(temp, sizeof(temp));
+    formatHMACKey(state.w, key, keyLen, 0x5C);
+    state.length += 64 * 8;
+    processChunk();
+    update(temp, hashSize());
+    finalize(hash, hashLen);
+    clean(temp);
+}
+
+/**
+ * \brief Processes a single 512-bit chunk with the core SHA-256 algorithm.
+ *
+ * Reference: http://en.wikipedia.org/wiki/SHA-2
+ */
+void SHA256::processChunk()
+{
+    // Round constants for SHA-256.
+    static uint32_t const k[64] PROGMEM = {
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+        0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+        0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+        0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+        0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+        0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+        0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+        0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+    };
+
+    // Convert the first 16 words from big endian to host byte order.
+    uint8_t index;
+    for (index = 0; index < 16; ++index)
+        state.w[index] = be32toh(state.w[index]);
+
+    // Initialise working variables to the current hash value.
+    uint32_t a = state.h[0];
+    uint32_t b = state.h[1];
+    uint32_t c = state.h[2];
+    uint32_t d = state.h[3];
+    uint32_t e = state.h[4];
+    uint32_t f = state.h[5];
+    uint32_t g = state.h[6];
+    uint32_t h = state.h[7];
+
+    // Perform the first 16 rounds of the compression function main loop.
+    uint32_t temp1, temp2;
+    for (index = 0; index < 16; ++index) {
+        temp1 = h + pgm_read_dword(k + index) + state.w[index] +
+                (rightRotate6(e) ^ rightRotate11(e) ^ rightRotate25(e)) +
+                ((e & f) ^ ((~e) & g));
+        temp2 = (rightRotate2(a) ^ rightRotate13(a) ^ rightRotate22(a)) +
+                ((a & b) ^ (a & c) ^ (b & c));
+        h = g;
+        g = f;
+        f = e;
+        e = d + temp1;
+        d = c;
+        c = b;
+        b = a;
+        a = temp1 + temp2;
+    }
+
+    // Perform the 48 remaining rounds.  We expand the first 16 words to
+    // 64 in-place in the "w" array.  This saves 192 bytes of memory
+    // that would have otherwise need to be allocated to the "w" array.
+    for (; index < 64; ++index) {
+        // Expand the next word.
+        temp1 = state.w[(index - 15) & 0x0F];
+        temp2 = state.w[(index - 2) & 0x0F];
+        temp1 = state.w[index & 0x0F] =
+            state.w[(index - 16) & 0x0F] + state.w[(index - 7) & 0x0F] +
+                (rightRotate7(temp1) ^ rightRotate18(temp1) ^ (temp1 >> 3)) +
+                (rightRotate17(temp2) ^ rightRotate19(temp2) ^ (temp2 >> 10));
+
+        // Perform the round.
+        temp1 = h + pgm_read_dword(k + index) + temp1 +
+                (rightRotate6(e) ^ rightRotate11(e) ^ rightRotate25(e)) +
+                ((e & f) ^ ((~e) & g));
+        temp2 = (rightRotate2(a) ^ rightRotate13(a) ^ rightRotate22(a)) +
+                ((a & b) ^ (a & c) ^ (b & c));
+        h = g;
+        g = f;
+        f = e;
+        e = d + temp1;
+        d = c;
+        c = b;
+        b = a;
+        a = temp1 + temp2;
+    }
+
+    // Add the compressed chunk to the current hash value.
+    state.h[0] += a;
+    state.h[1] += b;
+    state.h[2] += c;
+    state.h[3] += d;
+    state.h[4] += e;
+    state.h[5] += f;
+    state.h[6] += g;
+    state.h[7] += h;
+
+    // Attempt to clean up the stack.
+    a = b = c = d = e = f = g = h = temp1 = temp2 = 0;
+}

--- a/firmware/lib/Crypto/SHA256.h
+++ b/firmware/lib/Crypto/SHA256.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CRYPTO_SHA256_h
+#define CRYPTO_SHA256_h
+
+#include "Hash.h"
+
+class SHA256 : public Hash
+{
+public:
+    SHA256();
+    virtual ~SHA256();
+
+    size_t hashSize() const;
+    size_t blockSize() const;
+
+    void reset();
+    void update(const void *data, size_t len);
+    void finalize(void *hash, size_t len);
+
+    void clear();
+
+    void resetHMAC(const void *key, size_t keyLen);
+    void finalizeHMAC(const void *key, size_t keyLen, void *hash, size_t hashLen);
+
+protected:
+    struct {
+        uint32_t h[8];
+        uint32_t w[16];
+        uint64_t length;
+        uint8_t chunkSize;
+    } state;
+
+    void processChunk();
+};
+
+#endif

--- a/firmware/lib/Crypto/utility/EndianUtil.h
+++ b/firmware/lib/Crypto/utility/EndianUtil.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CRYPTO_ENDIANUTIL_H
+#define CRYPTO_ENDIANUTIL_H
+
+#include <inttypes.h>
+
+#if !defined(HOST_BUILD)
+
+// CPU is assumed to be little endian.   Edit this file if you
+// need to port this library to a big endian CPU.
+
+#define CRYPTO_LITTLE_ENDIAN 1
+
+#define htole16(x)  (x)
+#define le16toh(x)  (x)
+#define htobe16(x)  \
+    (__extension__ ({ \
+        uint16_t _temp = (x); \
+        ((_temp >> 8) & 0x00FF) | \
+        ((_temp << 8) & 0xFF00); \
+    }))
+#define be16toh(x)  (htobe16((x)))
+
+#define htole32(x)  (x)
+#define le32toh(x)  (x)
+#define htobe32(x)  \
+    (__extension__ ({ \
+        uint32_t _temp = (x); \
+        ((_temp >> 24) & 0x000000FF) | \
+        ((_temp >>  8) & 0x0000FF00) | \
+        ((_temp <<  8) & 0x00FF0000) | \
+        ((_temp << 24) & 0xFF000000); \
+    }))
+#define be32toh(x)  (htobe32((x)))
+
+#define htole64(x)  (x)
+#define le64toh(x)  (x)
+#define htobe64(x)  \
+    (__extension__ ({ \
+        uint64_t __temp = (x); \
+        uint32_t __low = htobe32((uint32_t)__temp); \
+        uint32_t __high = htobe32((uint32_t)(__temp >> 32)); \
+        (((uint64_t)__low) << 32) | __high; \
+    }))
+#define be64toh(x)  (htobe64((x)))
+
+#else // HOST_BUILD
+
+#include <endian.h>
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#define CRYPTO_LITTLE_ENDIAN 1
+#endif
+
+#endif // HOST_BUILD
+
+#endif

--- a/firmware/lib/Crypto/utility/LimbUtil.h
+++ b/firmware/lib/Crypto/utility/LimbUtil.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CRYPTO_LIMBUTIL_H
+#define CRYPTO_LIMBUTIL_H
+
+#include "ProgMemUtil.h"
+
+// Number of limbs in a big number value of various sizes.
+#define NUM_LIMBS_BITS(n) \
+    (((n) + sizeof(limb_t) * 8 - 1) / (8 * sizeof(limb_t)))
+#define NUM_LIMBS_128BIT NUM_LIMBS_BITS(128)
+#define NUM_LIMBS_256BIT NUM_LIMBS_BITS(256)
+#define NUM_LIMBS_512BIT NUM_LIMBS_BITS(512)
+
+// The number of bits in a limb.
+#define LIMB_BITS   (8 * sizeof(limb_t))
+
+// Read a limb-sized quantity from program memory.
+#if BIGNUMBER_LIMB_8BIT
+#define pgm_read_limb(x)    (pgm_read_byte((x)))
+#elif BIGNUMBER_LIMB_16BIT
+#define pgm_read_limb(x)    (pgm_read_word((x)))
+#elif BIGNUMBER_LIMB_32BIT
+#define pgm_read_limb(x)    (pgm_read_dword((x)))
+#elif BIGNUMBER_LIMB_64BIT
+#define pgm_read_limb(x)    (pgm_read_qword((x)))
+#endif
+
+// Expand a 32-bit value into a set of limbs depending upon the limb size.
+// This is used when initializing constant big number values in the code.
+// For 64-bit system compatibility it is necessary to use LIMB_PAIR(x, y).
+#if BIGNUMBER_LIMB_8BIT
+#define LIMB(value)     ((uint8_t)(value)), \
+                        ((uint8_t)((value) >> 8)), \
+                        ((uint8_t)((value) >> 16)), \
+                        ((uint8_t)((value) >> 24))
+#define LIMB_PAIR(x,y)  LIMB((x)), LIMB((y))
+#elif BIGNUMBER_LIMB_16BIT
+#define LIMB(value)     ((uint16_t)(value)), \
+                        ((uint16_t)(((uint32_t)(value)) >> 16))
+#define LIMB_PAIR(x,y)  LIMB((x)), LIMB((y))
+#elif BIGNUMBER_LIMB_32BIT
+#define LIMB(value)     (value)
+#define LIMB_PAIR(x,y)  LIMB((x)), LIMB((y))
+#elif BIGNUMBER_LIMB_64BIT
+#define LIMB(value)     (value)
+#define LIMB_PAIR(x,y)  ((((uint64_t)(y)) << 32) | ((uint64_t)(x)))
+#endif
+
+#endif

--- a/firmware/lib/Crypto/utility/ProgMemUtil.h
+++ b/firmware/lib/Crypto/utility/ProgMemUtil.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CRYPTO_PROGMEMUTIL_H
+#define CRYPTO_PROGMEMUTIL_H
+
+#if defined(__AVR__)
+#include <avr/pgmspace.h>
+#define pgm_read_qword(x)   \
+    (__extension__ ({ \
+        const uint32_t *_temp = (const uint32_t *)(x); \
+        ((uint64_t)pgm_read_dword(_temp)) | \
+        (((uint64_t)pgm_read_dword(_temp + 1)) << 32); \
+    }))
+#elif defined(ESP8266) || defined(ESP32)
+#include <pgmspace.h>
+#define pgm_read_qword(x)   \
+    (__extension__ ({ \
+        const uint32_t *_temp = (const uint32_t *)(x); \
+        ((uint64_t)pgm_read_dword(_temp)) | \
+        (((uint64_t)pgm_read_dword(_temp + 1)) << 32); \
+    }))
+#else
+#include <string.h>
+#define PROGMEM
+#ifndef pgm_read_byte
+# define pgm_read_byte(x)    (*(x))
+#endif
+#ifndef pgm_read_word
+# define pgm_read_word(x)    (*(x))
+#endif
+#ifndef pgm_read_dword
+# define pgm_read_dword(x)   (*(x))
+#endif
+#ifndef pgm_read_qword
+# define pgm_read_qword(x)   (*(x))
+#endif
+#ifndef memcpy_P
+# define memcpy_P(d,s,l)     memcpy((d), (s), (l))
+#endif
+#endif
+
+#endif

--- a/firmware/lib/Crypto/utility/RotateUtil.h
+++ b/firmware/lib/Crypto/utility/RotateUtil.h
@@ -1,0 +1,696 @@
+/*
+ * Copyright (C) 2015 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CRYPTO_ROTATEUTIL_H
+#define CRYPTO_ROTATEUTIL_H
+
+#include <inttypes.h>
+
+// Rotation functions that are optimised for best performance on AVR.
+// The most efficient rotations are where the number of bits is 1 or a
+// multiple of 8, so we compose the efficient rotations to produce all
+// other rotation counts of interest.
+
+#if defined(__AVR__)
+#define CRYPTO_ROTATE32_COMPOSED 1
+#define CRYPTO_ROTATE64_COMPOSED 0
+#else
+#define CRYPTO_ROTATE32_COMPOSED 0
+#define CRYPTO_ROTATE64_COMPOSED 0
+#endif
+
+#if CRYPTO_ROTATE32_COMPOSED
+
+// Rotation macros for 32-bit arguments.
+
+// Generic left rotate - best performance when "bits" is 1 or a multiple of 8.
+#define leftRotate(a, bits) \
+    (__extension__ ({ \
+        uint32_t _temp = (a); \
+        (_temp << (bits)) | (_temp >> (32 - (bits))); \
+    }))
+
+// Generic right rotate - best performance when "bits" is 1 or a multiple of 8.
+#define rightRotate(a, bits) \
+    (__extension__ ({ \
+        uint32_t _temp = (a); \
+        (_temp >> (bits)) | (_temp << (32 - (bits))); \
+    }))
+
+// Left rotate by 1.
+#define leftRotate1(a)  (leftRotate((a), 1))
+
+// Left rotate by 2.
+#define leftRotate2(a)  (leftRotate(leftRotate((a), 1), 1))
+
+// Left rotate by 3.
+#define leftRotate3(a)  (leftRotate(leftRotate(leftRotate((a), 1), 1), 1))
+
+// Left rotate by 4.
+#define leftRotate4(a)  (leftRotate(leftRotate(leftRotate(leftRotate((a), 1), 1), 1), 1))
+
+// Left rotate by 5: Rotate left by 8, then right by 3.
+#define leftRotate5(a)  (rightRotate(rightRotate(rightRotate(leftRotate((a), 8), 1), 1), 1))
+
+// Left rotate by 6: Rotate left by 8, then right by 2.
+#define leftRotate6(a)  (rightRotate(rightRotate(leftRotate((a), 8), 1), 1))
+
+// Left rotate by 7: Rotate left by 8, then right by 1.
+#define leftRotate7(a)  (rightRotate(leftRotate((a), 8), 1))
+
+// Left rotate by 8.
+#define leftRotate8(a)  (leftRotate((a), 8))
+
+// Left rotate by 9: Rotate left by 8, then left by 1.
+#define leftRotate9(a)  (leftRotate(leftRotate((a), 8), 1))
+
+// Left rotate by 10: Rotate left by 8, then left by 2.
+#define leftRotate10(a) (leftRotate(leftRotate(leftRotate((a), 8), 1), 1))
+
+// Left rotate by 11: Rotate left by 8, then left by 3.
+#define leftRotate11(a) (leftRotate(leftRotate(leftRotate(leftRotate((a), 8), 1), 1), 1))
+
+// Left rotate by 12: Rotate left by 16, then right by 4.
+#define leftRotate12(a) (rightRotate(rightRotate(rightRotate(rightRotate(leftRotate((a), 16), 1), 1), 1), 1))
+
+// Left rotate by 13: Rotate left by 16, then right by 3.
+#define leftRotate13(a) (rightRotate(rightRotate(rightRotate(leftRotate((a), 16), 1), 1), 1))
+
+// Left rotate by 14: Rotate left by 16, then right by 2.
+#define leftRotate14(a) (rightRotate(rightRotate(leftRotate((a), 16), 1), 1))
+
+// Left rotate by 15: Rotate left by 16, then right by 1.
+#define leftRotate15(a) (rightRotate(leftRotate((a), 16), 1))
+
+// Left rotate by 16.
+#define leftRotate16(a) (leftRotate((a), 16))
+
+// Left rotate by 17: Rotate left by 16, then left by 1.
+#define leftRotate17(a) (leftRotate(leftRotate((a), 16), 1))
+
+// Left rotate by 18: Rotate left by 16, then left by 2.
+#define leftRotate18(a) (leftRotate(leftRotate(leftRotate((a), 16), 1), 1))
+
+// Left rotate by 19: Rotate left by 16, then left by 3.
+#define leftRotate19(a) (leftRotate(leftRotate(leftRotate(leftRotate((a), 16), 1), 1), 1))
+
+// Left rotate by 20: Rotate left by 16, then left by 4.
+#define leftRotate20(a) (leftRotate(leftRotate(leftRotate(leftRotate(leftRotate((a), 16), 1), 1), 1), 1))
+
+// Left rotate by 21: Rotate left by 24, then right by 3.
+#define leftRotate21(a) (rightRotate(rightRotate(rightRotate(leftRotate((a), 24), 1), 1), 1))
+
+// Left rotate by 22: Rotate left by 24, then right by 2.
+#define leftRotate22(a) (rightRotate(rightRotate(leftRotate((a), 24), 1), 1))
+
+// Left rotate by 23: Rotate left by 24, then right by 1.
+#define leftRotate23(a) (rightRotate(leftRotate((a), 24), 1))
+
+// Left rotate by 24.
+#define leftRotate24(a) (leftRotate((a), 24))
+
+// Left rotate by 25: Rotate left by 24, then left by 1.
+#define leftRotate25(a) (leftRotate(leftRotate((a), 24), 1))
+
+// Left rotate by 26: Rotate left by 24, then left by 2.
+#define leftRotate26(a) (leftRotate(leftRotate(leftRotate((a), 24), 1), 1))
+
+// Left rotate by 27: Rotate left by 24, then left by 3.
+#define leftRotate27(a) (leftRotate(leftRotate(leftRotate(leftRotate((a), 24), 1), 1), 1))
+
+// Left rotate by 28: Rotate right by 4.
+#define leftRotate28(a) (rightRotate(rightRotate(rightRotate(rightRotate((a), 1), 1), 1), 1))
+
+// Left rotate by 29: Rotate right by 3.
+#define leftRotate29(a) (rightRotate(rightRotate(rightRotate((a), 1), 1), 1))
+
+// Left rotate by 30: Rotate right by 2.
+#define leftRotate30(a) (rightRotate(rightRotate((a), 1), 1))
+
+// Left rotate by 31: Rotate right by 1.
+#define leftRotate31(a) (rightRotate((a), 1))
+
+// Define the 32-bit right rotations in terms of left rotations.
+#define rightRotate1(a)  (leftRotate31((a)))
+#define rightRotate2(a)  (leftRotate30((a)))
+#define rightRotate3(a)  (leftRotate29((a)))
+#define rightRotate4(a)  (leftRotate28((a)))
+#define rightRotate5(a)  (leftRotate27((a)))
+#define rightRotate6(a)  (leftRotate26((a)))
+#define rightRotate7(a)  (leftRotate25((a)))
+#define rightRotate8(a)  (leftRotate24((a)))
+#define rightRotate9(a)  (leftRotate23((a)))
+#define rightRotate10(a) (leftRotate22((a)))
+#define rightRotate11(a) (leftRotate21((a)))
+#define rightRotate12(a) (leftRotate20((a)))
+#define rightRotate13(a) (leftRotate19((a)))
+#define rightRotate14(a) (leftRotate18((a)))
+#define rightRotate15(a) (leftRotate17((a)))
+#define rightRotate16(a) (leftRotate16((a)))
+#define rightRotate17(a) (leftRotate15((a)))
+#define rightRotate18(a) (leftRotate14((a)))
+#define rightRotate19(a) (leftRotate13((a)))
+#define rightRotate20(a) (leftRotate12((a)))
+#define rightRotate21(a) (leftRotate11((a)))
+#define rightRotate22(a) (leftRotate10((a)))
+#define rightRotate23(a) (leftRotate9((a)))
+#define rightRotate24(a) (leftRotate8((a)))
+#define rightRotate25(a) (leftRotate7((a)))
+#define rightRotate26(a) (leftRotate6((a)))
+#define rightRotate27(a) (leftRotate5((a)))
+#define rightRotate28(a) (leftRotate4((a)))
+#define rightRotate29(a) (leftRotate3((a)))
+#define rightRotate30(a) (leftRotate2((a)))
+#define rightRotate31(a) (leftRotate1((a)))
+
+#else // !CRYPTO_ROTATE32_COMPOSED
+
+// Generic rotation functions.  All bit shifts are considered to have
+// similar performance.  Usually true of 32-bit and higher platforms.
+
+// Rotation macros for 32-bit arguments.
+
+// Generic left rotate.
+#define leftRotate(a, bits) \
+    (__extension__ ({ \
+        uint32_t _temp = (a); \
+        (_temp << (bits)) | (_temp >> (32 - (bits))); \
+    }))
+
+// Generic right rotate.
+#define rightRotate(a, bits) \
+    (__extension__ ({ \
+        uint32_t _temp = (a); \
+        (_temp >> (bits)) | (_temp << (32 - (bits))); \
+    }))
+
+// Left rotate by a specific number of bits.
+#define leftRotate1(a)  (leftRotate((a), 1))
+#define leftRotate2(a)  (leftRotate((a), 2))
+#define leftRotate3(a)  (leftRotate((a), 3))
+#define leftRotate4(a)  (leftRotate((a), 4))
+#define leftRotate5(a)  (leftRotate((a), 5))
+#define leftRotate6(a)  (leftRotate((a), 6))
+#define leftRotate7(a)  (leftRotate((a), 7))
+#define leftRotate8(a)  (leftRotate((a), 8))
+#define leftRotate9(a)  (leftRotate((a), 9))
+#define leftRotate10(a) (leftRotate((a), 10))
+#define leftRotate11(a) (leftRotate((a), 11))
+#define leftRotate12(a) (leftRotate((a), 12))
+#define leftRotate13(a) (leftRotate((a), 13))
+#define leftRotate14(a) (leftRotate((a), 14))
+#define leftRotate15(a) (leftRotate((a), 15))
+#define leftRotate16(a) (leftRotate((a), 16))
+#define leftRotate17(a) (leftRotate((a), 17))
+#define leftRotate18(a) (leftRotate((a), 18))
+#define leftRotate19(a) (leftRotate((a), 19))
+#define leftRotate20(a) (leftRotate((a), 20))
+#define leftRotate21(a) (leftRotate((a), 21))
+#define leftRotate22(a) (leftRotate((a), 22))
+#define leftRotate23(a) (leftRotate((a), 23))
+#define leftRotate24(a) (leftRotate((a), 24))
+#define leftRotate25(a) (leftRotate((a), 25))
+#define leftRotate26(a) (leftRotate((a), 26))
+#define leftRotate27(a) (leftRotate((a), 27))
+#define leftRotate28(a) (leftRotate((a), 28))
+#define leftRotate29(a) (leftRotate((a), 29))
+#define leftRotate30(a) (leftRotate((a), 30))
+#define leftRotate31(a) (leftRotate((a), 31))
+
+// Right rotate by a specific number of bits.
+#define rightRotate1(a)  (rightRotate((a), 1))
+#define rightRotate2(a)  (rightRotate((a), 2))
+#define rightRotate3(a)  (rightRotate((a), 3))
+#define rightRotate4(a)  (rightRotate((a), 4))
+#define rightRotate5(a)  (rightRotate((a), 5))
+#define rightRotate6(a)  (rightRotate((a), 6))
+#define rightRotate7(a)  (rightRotate((a), 7))
+#define rightRotate8(a)  (rightRotate((a), 8))
+#define rightRotate9(a)  (rightRotate((a), 9))
+#define rightRotate10(a) (rightRotate((a), 10))
+#define rightRotate11(a) (rightRotate((a), 11))
+#define rightRotate12(a) (rightRotate((a), 12))
+#define rightRotate13(a) (rightRotate((a), 13))
+#define rightRotate14(a) (rightRotate((a), 14))
+#define rightRotate15(a) (rightRotate((a), 15))
+#define rightRotate16(a) (rightRotate((a), 16))
+#define rightRotate17(a) (rightRotate((a), 17))
+#define rightRotate18(a) (rightRotate((a), 18))
+#define rightRotate19(a) (rightRotate((a), 19))
+#define rightRotate20(a) (rightRotate((a), 20))
+#define rightRotate21(a) (rightRotate((a), 21))
+#define rightRotate22(a) (rightRotate((a), 22))
+#define rightRotate23(a) (rightRotate((a), 23))
+#define rightRotate24(a) (rightRotate((a), 24))
+#define rightRotate25(a) (rightRotate((a), 25))
+#define rightRotate26(a) (rightRotate((a), 26))
+#define rightRotate27(a) (rightRotate((a), 27))
+#define rightRotate28(a) (rightRotate((a), 28))
+#define rightRotate29(a) (rightRotate((a), 29))
+#define rightRotate30(a) (rightRotate((a), 30))
+#define rightRotate31(a) (rightRotate((a), 31))
+
+#endif // !CRYPTO_ROTATE32_COMPOSED
+
+#if CRYPTO_ROTATE64_COMPOSED
+
+// Rotation macros for 64-bit arguments.
+
+// Generic left rotate - best performance when "bits" is 1 or a multiple of 8.
+#define leftRotate_64(a, bits) \
+    (__extension__ ({ \
+        uint64_t _temp = (a); \
+        (_temp << (bits)) | (_temp >> (64 - (bits))); \
+    }))
+
+// Generic right rotate - best performance when "bits" is 1 or a multiple of 8.
+#define rightRotate_64(a, bits) \
+    (__extension__ ({ \
+        uint64_t _temp = (a); \
+        (_temp >> (bits)) | (_temp << (64 - (bits))); \
+    }))
+
+// Left rotate by 1.
+#define leftRotate1_64(a)  (leftRotate_64((a), 1))
+
+// Left rotate by 2.
+#define leftRotate2_64(a)  (leftRotate_64(leftRotate_64((a), 1), 1))
+
+// Left rotate by 3.
+#define leftRotate3_64(a)  (leftRotate_64(leftRotate_64(leftRotate_64((a), 1), 1), 1))
+
+// Left rotate by 4.
+#define leftRotate4_64(a)  (leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64((a), 1), 1), 1), 1))
+
+// Left rotate by 5: Rotate left by 8, then right by 3.
+#define leftRotate5_64(a)  (rightRotate_64(rightRotate_64(rightRotate_64(leftRotate_64((a), 8), 1), 1), 1))
+
+// Left rotate by 6: Rotate left by 8, then right by 2.
+#define leftRotate6_64(a)  (rightRotate_64(rightRotate_64(leftRotate_64((a), 8), 1), 1))
+
+// Left rotate by 7: Rotate left by 8, then right by 1.
+#define leftRotate7_64(a)  (rightRotate_64(leftRotate_64((a), 8), 1))
+
+// Left rotate by 8.
+#define leftRotate8_64(a)  (leftRotate_64((a), 8))
+
+// Left rotate by 9: Rotate left by 8, then left by 1.
+#define leftRotate9_64(a)  (leftRotate_64(leftRotate_64((a), 8), 1))
+
+// Left rotate by 10: Rotate left by 8, then left by 2.
+#define leftRotate10_64(a) (leftRotate_64(leftRotate_64(leftRotate_64((a), 8), 1), 1))
+
+// Left rotate by 11: Rotate left by 8, then left by 3.
+#define leftRotate11_64(a) (leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64((a), 8), 1), 1), 1))
+
+// Left rotate by 12: Rotate left by 16, then right by 4.
+#define leftRotate12_64(a) (rightRotate_64(rightRotate_64(rightRotate_64(rightRotate_64(leftRotate_64((a), 16), 1), 1), 1), 1))
+
+// Left rotate by 13: Rotate left by 16, then right by 3.
+#define leftRotate13_64(a) (rightRotate_64(rightRotate_64(rightRotate_64(leftRotate_64((a), 16), 1), 1), 1))
+
+// Left rotate by 14: Rotate left by 16, then right by 2.
+#define leftRotate14_64(a) (rightRotate_64(rightRotate_64(leftRotate_64((a), 16), 1), 1))
+
+// Left rotate by 15: Rotate left by 16, then right by 1.
+#define leftRotate15_64(a) (rightRotate_64(leftRotate_64((a), 16), 1))
+
+// Left rotate by 16.
+#define leftRotate16_64(a) (leftRotate_64((a), 16))
+
+// Left rotate by 17: Rotate left by 16, then left by 1.
+#define leftRotate17_64(a) (leftRotate_64(leftRotate_64((a), 16), 1))
+
+// Left rotate by 18: Rotate left by 16, then left by 2.
+#define leftRotate18_64(a) (leftRotate_64(leftRotate_64(leftRotate_64((a), 16), 1), 1))
+
+// Left rotate by 19: Rotate left by 16, then left by 3.
+#define leftRotate19_64(a) (leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64((a), 16), 1), 1), 1))
+
+// Left rotate by 20: Rotate left by 16, then left by 4.
+#define leftRotate20_64(a) (leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64((a), 16), 1), 1), 1), 1))
+
+// Left rotate by 21: Rotate left by 24, then right by 3.
+#define leftRotate21_64(a) (rightRotate_64(rightRotate_64(rightRotate_64(leftRotate_64((a), 24), 1), 1), 1))
+
+// Left rotate by 22: Rotate left by 24, then right by 2.
+#define leftRotate22_64(a) (rightRotate_64(rightRotate_64(leftRotate_64((a), 24), 1), 1))
+
+// Left rotate by 23: Rotate left by 24, then right by 1.
+#define leftRotate23_64(a) (rightRotate_64(leftRotate_64((a), 24), 1))
+
+// Left rotate by 24.
+#define leftRotate24_64(a) (leftRotate_64((a), 24))
+
+// Left rotate by 25: Rotate left by 24, then left by 1.
+#define leftRotate25_64(a) (leftRotate_64(leftRotate_64((a), 24), 1))
+
+// Left rotate by 26: Rotate left by 24, then left by 2.
+#define leftRotate26_64(a) (leftRotate_64(leftRotate_64(leftRotate_64((a), 24), 1), 1))
+
+// Left rotate by 27: Rotate left by 24, then left by 3.
+#define leftRotate27_64(a) (leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64((a), 24), 1), 1), 1))
+
+// Left rotate by 28: Rotate left by 24, then left by 4.
+#define leftRotate28_64(a) (leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64((a), 24), 1), 1), 1), 1))
+
+// Left rotate by 29: Rotate left by 32, then right by 3.
+#define leftRotate29_64(a) (rightRotate_64(rightRotate_64(rightRotate_64(leftRotate_64((a), 32), 1), 1), 1))
+
+// Left rotate by 30: Rotate left by 32, then right by 2.
+#define leftRotate30_64(a) (rightRotate_64(rightRotate_64(leftRotate_64((a), 32), 1), 1))
+
+// Left rotate by 31: Rotate left by 32, then right by 1.
+#define leftRotate31_64(a) (rightRotate_64(leftRotate_64((a), 32), 1))
+
+// Left rotate by 32.
+#define leftRotate32_64(a) (leftRotate_64((a), 32))
+
+// Left rotate by 33: Rotate left by 32, then left by 1.
+#define leftRotate33_64(a) (leftRotate_64(leftRotate_64((a), 32), 1))
+
+// Left rotate by 34: Rotate left by 32, then left by 2.
+#define leftRotate34_64(a) (leftRotate_64(leftRotate_64(leftRotate_64((a), 32), 1), 1))
+
+// Left rotate by 35: Rotate left by 32, then left by 3.
+#define leftRotate35_64(a) (leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64((a), 32), 1), 1), 1))
+
+// Left rotate by 36: Rotate left by 32, then left by 4.
+#define leftRotate36_64(a) (leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64((a), 32), 1), 1), 1), 1))
+
+// Left rotate by 37: Rotate left by 40, then right by 3.
+#define leftRotate37_64(a) (rightRotate_64(rightRotate_64(rightRotate_64(leftRotate_64((a), 40), 1), 1), 1))
+
+// Left rotate by 38: Rotate left by 40, then right by 2.
+#define leftRotate38_64(a) (rightRotate_64(rightRotate_64(leftRotate_64((a), 40), 1), 1))
+
+// Left rotate by 39: Rotate left by 40, then right by 1.
+#define leftRotate39_64(a) (rightRotate_64(leftRotate_64((a), 40), 1))
+
+// Left rotate by 40.
+#define leftRotate40_64(a) (leftRotate_64((a), 40))
+
+// Left rotate by 41: Rotate left by 40, then left by 1.
+#define leftRotate41_64(a) (leftRotate_64(leftRotate_64((a), 40), 1))
+
+// Left rotate by 42: Rotate left by 40, then left by 2.
+#define leftRotate42_64(a) (leftRotate_64(leftRotate_64(leftRotate_64((a), 40), 1), 1))
+
+// Left rotate by 43: Rotate left by 40, then left by 3.
+#define leftRotate43_64(a) (leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64((a), 40), 1), 1), 1))
+
+// Left rotate by 44: Rotate left by 40, then left by 4.
+#define leftRotate44_64(a) (leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64((a), 40), 1), 1), 1), 1))
+
+// Left rotate by 45: Rotate left by 48, then right by 3.
+#define leftRotate45_64(a) (rightRotate_64(rightRotate_64(rightRotate_64(leftRotate_64((a), 48), 1), 1), 1))
+
+// Left rotate by 46: Rotate left by 48, then right by 2.
+#define leftRotate46_64(a) (rightRotate_64(rightRotate_64(leftRotate_64((a), 48), 1), 1))
+
+// Left rotate by 47: Rotate left by 48, then right by 1.
+#define leftRotate47_64(a) (rightRotate_64(leftRotate_64((a), 48), 1))
+
+// Left rotate by 48.
+#define leftRotate48_64(a) (leftRotate_64((a), 48))
+
+// Left rotate by 49: Rotate left by 48, then left by 1.
+#define leftRotate49_64(a) (leftRotate_64(leftRotate_64((a), 48), 1))
+
+// Left rotate by 50: Rotate left by 48, then left by 2.
+#define leftRotate50_64(a) (leftRotate_64(leftRotate_64(leftRotate_64((a), 48), 1), 1))
+
+// Left rotate by 51: Rotate left by 48, then left by 3.
+#define leftRotate51_64(a) (leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64((a), 48), 1), 1), 1))
+
+// Left rotate by 52: Rotate left by 48, then left by 4.
+#define leftRotate52_64(a) (leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64((a), 48), 1), 1), 1), 1))
+
+// Left rotate by 53: Rotate left by 56, then right by 3.
+#define leftRotate53_64(a) (rightRotate_64(rightRotate_64(rightRotate_64(leftRotate_64((a), 56), 1), 1), 1))
+
+// Left rotate by 54: Rotate left by 56, then right by 2.
+#define leftRotate54_64(a) (rightRotate_64(rightRotate_64(leftRotate_64((a), 56), 1), 1))
+
+// Left rotate by 55: Rotate left by 56, then right by 1.
+#define leftRotate55_64(a) (rightRotate_64(leftRotate_64((a), 56), 1))
+
+// Left rotate by 56.
+#define leftRotate56_64(a) (leftRotate_64((a), 56))
+
+// Left rotate by 57: Rotate left by 56, then left by 1.
+#define leftRotate57_64(a) (leftRotate_64(leftRotate_64((a), 56), 1))
+
+// Left rotate by 58: Rotate left by 56, then left by 2.
+#define leftRotate58_64(a) (leftRotate_64(leftRotate_64(leftRotate_64((a), 56), 1), 1))
+
+// Left rotate by 59: Rotate left by 56, then left by 3.
+#define leftRotate59_64(a) (leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64((a), 56), 1), 1), 1))
+
+// Left rotate by 60: Rotate left by 60, then left by 4.
+#define leftRotate60_64(a) (leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64(leftRotate_64((a), 56), 1), 1), 1), 1))
+
+// Left rotate by 61: Rotate right by 3.
+#define leftRotate61_64(a) (rightRotate_64(rightRotate_64(rightRotate_64((a), 1), 1), 1))
+
+// Left rotate by 62: Rotate right by 2.
+#define leftRotate62_64(a) (rightRotate_64(rightRotate_64((a), 1), 1))
+
+// Left rotate by 63: Rotate right by 1.
+#define leftRotate63_64(a) (rightRotate_64((a), 1))
+
+// Define the 64-bit right rotations in terms of left rotations.
+#define rightRotate1_64(a)  (leftRotate63_64((a)))
+#define rightRotate2_64(a)  (leftRotate62_64((a)))
+#define rightRotate3_64(a)  (leftRotate61_64((a)))
+#define rightRotate4_64(a)  (leftRotate60_64((a)))
+#define rightRotate5_64(a)  (leftRotate59_64((a)))
+#define rightRotate6_64(a)  (leftRotate58_64((a)))
+#define rightRotate7_64(a)  (leftRotate57_64((a)))
+#define rightRotate8_64(a)  (leftRotate56_64((a)))
+#define rightRotate9_64(a)  (leftRotate55_64((a)))
+#define rightRotate10_64(a) (leftRotate54_64((a)))
+#define rightRotate11_64(a) (leftRotate53_64((a)))
+#define rightRotate12_64(a) (leftRotate52_64((a)))
+#define rightRotate13_64(a) (leftRotate51_64((a)))
+#define rightRotate14_64(a) (leftRotate50_64((a)))
+#define rightRotate15_64(a) (leftRotate49_64((a)))
+#define rightRotate16_64(a) (leftRotate48_64((a)))
+#define rightRotate17_64(a) (leftRotate47_64((a)))
+#define rightRotate18_64(a) (leftRotate46_64((a)))
+#define rightRotate19_64(a) (leftRotate45_64((a)))
+#define rightRotate20_64(a) (leftRotate44_64((a)))
+#define rightRotate21_64(a) (leftRotate43_64((a)))
+#define rightRotate22_64(a) (leftRotate42_64((a)))
+#define rightRotate23_64(a) (leftRotate41_64((a)))
+#define rightRotate24_64(a) (leftRotate40_64((a)))
+#define rightRotate25_64(a) (leftRotate39_64((a)))
+#define rightRotate26_64(a) (leftRotate38_64((a)))
+#define rightRotate27_64(a) (leftRotate37_64((a)))
+#define rightRotate28_64(a) (leftRotate36_64((a)))
+#define rightRotate29_64(a) (leftRotate35_64((a)))
+#define rightRotate30_64(a) (leftRotate34_64((a)))
+#define rightRotate31_64(a) (leftRotate33_64((a)))
+#define rightRotate32_64(a) (leftRotate32_64((a)))
+#define rightRotate33_64(a) (leftRotate31_64((a)))
+#define rightRotate34_64(a) (leftRotate30_64((a)))
+#define rightRotate35_64(a) (leftRotate29_64((a)))
+#define rightRotate36_64(a) (leftRotate28_64((a)))
+#define rightRotate37_64(a) (leftRotate27_64((a)))
+#define rightRotate38_64(a) (leftRotate26_64((a)))
+#define rightRotate39_64(a) (leftRotate25_64((a)))
+#define rightRotate40_64(a) (leftRotate24_64((a)))
+#define rightRotate41_64(a) (leftRotate23_64((a)))
+#define rightRotate42_64(a) (leftRotate22_64((a)))
+#define rightRotate43_64(a) (leftRotate21_64((a)))
+#define rightRotate44_64(a) (leftRotate20_64((a)))
+#define rightRotate45_64(a) (leftRotate19_64((a)))
+#define rightRotate46_64(a) (leftRotate18_64((a)))
+#define rightRotate47_64(a) (leftRotate17_64((a)))
+#define rightRotate48_64(a) (leftRotate16_64((a)))
+#define rightRotate49_64(a) (leftRotate15_64((a)))
+#define rightRotate50_64(a) (leftRotate14_64((a)))
+#define rightRotate51_64(a) (leftRotate13_64((a)))
+#define rightRotate52_64(a) (leftRotate12_64((a)))
+#define rightRotate53_64(a) (leftRotate11_64((a)))
+#define rightRotate54_64(a) (leftRotate10_64((a)))
+#define rightRotate55_64(a) (leftRotate9_64((a)))
+#define rightRotate56_64(a) (leftRotate8_64((a)))
+#define rightRotate57_64(a) (leftRotate7_64((a)))
+#define rightRotate58_64(a) (leftRotate6_64((a)))
+#define rightRotate59_64(a) (leftRotate5_64((a)))
+#define rightRotate60_64(a) (leftRotate4_64((a)))
+#define rightRotate61_64(a) (leftRotate3_64((a)))
+#define rightRotate62_64(a) (leftRotate2_64((a)))
+#define rightRotate63_64(a) (leftRotate1_64((a)))
+
+#else // !CRYPTO_ROTATE64_COMPOSED
+
+// Rotation macros for 64-bit arguments.
+
+// Generic left rotate.
+#define leftRotate_64(a, bits) \
+    (__extension__ ({ \
+        uint64_t _temp = (a); \
+        (_temp << (bits)) | (_temp >> (64 - (bits))); \
+    }))
+
+// Generic right rotate.
+#define rightRotate_64(a, bits) \
+    (__extension__ ({ \
+        uint64_t _temp = (a); \
+        (_temp >> (bits)) | (_temp << (64 - (bits))); \
+    }))
+
+// Left rotate by a specific number of bits.
+#define leftRotate1_64(a)  (leftRotate_64((a), 1))
+#define leftRotate2_64(a)  (leftRotate_64((a), 2))
+#define leftRotate3_64(a)  (leftRotate_64((a), 3))
+#define leftRotate4_64(a)  (leftRotate_64((a), 4))
+#define leftRotate5_64(a)  (leftRotate_64((a), 5))
+#define leftRotate6_64(a)  (leftRotate_64((a), 6))
+#define leftRotate7_64(a)  (leftRotate_64((a), 7))
+#define leftRotate8_64(a)  (leftRotate_64((a), 8))
+#define leftRotate9_64(a)  (leftRotate_64((a), 9))
+#define leftRotate10_64(a) (leftRotate_64((a), 10))
+#define leftRotate11_64(a) (leftRotate_64((a), 11))
+#define leftRotate12_64(a) (leftRotate_64((a), 12))
+#define leftRotate13_64(a) (leftRotate_64((a), 13))
+#define leftRotate14_64(a) (leftRotate_64((a), 14))
+#define leftRotate15_64(a) (leftRotate_64((a), 15))
+#define leftRotate16_64(a) (leftRotate_64((a), 16))
+#define leftRotate17_64(a) (leftRotate_64((a), 17))
+#define leftRotate18_64(a) (leftRotate_64((a), 18))
+#define leftRotate19_64(a) (leftRotate_64((a), 19))
+#define leftRotate20_64(a) (leftRotate_64((a), 20))
+#define leftRotate21_64(a) (leftRotate_64((a), 21))
+#define leftRotate22_64(a) (leftRotate_64((a), 22))
+#define leftRotate23_64(a) (leftRotate_64((a), 23))
+#define leftRotate24_64(a) (leftRotate_64((a), 24))
+#define leftRotate25_64(a) (leftRotate_64((a), 25))
+#define leftRotate26_64(a) (leftRotate_64((a), 26))
+#define leftRotate27_64(a) (leftRotate_64((a), 27))
+#define leftRotate28_64(a) (leftRotate_64((a), 28))
+#define leftRotate29_64(a) (leftRotate_64((a), 29))
+#define leftRotate30_64(a) (leftRotate_64((a), 30))
+#define leftRotate31_64(a) (leftRotate_64((a), 31))
+#define leftRotate32_64(a) (leftRotate_64((a), 32))
+#define leftRotate33_64(a) (leftRotate_64((a), 33))
+#define leftRotate34_64(a) (leftRotate_64((a), 34))
+#define leftRotate35_64(a) (leftRotate_64((a), 35))
+#define leftRotate36_64(a) (leftRotate_64((a), 36))
+#define leftRotate37_64(a) (leftRotate_64((a), 37))
+#define leftRotate38_64(a) (leftRotate_64((a), 38))
+#define leftRotate39_64(a) (leftRotate_64((a), 39))
+#define leftRotate40_64(a) (leftRotate_64((a), 40))
+#define leftRotate41_64(a) (leftRotate_64((a), 41))
+#define leftRotate42_64(a) (leftRotate_64((a), 42))
+#define leftRotate43_64(a) (leftRotate_64((a), 43))
+#define leftRotate44_64(a) (leftRotate_64((a), 44))
+#define leftRotate45_64(a) (leftRotate_64((a), 45))
+#define leftRotate46_64(a) (leftRotate_64((a), 46))
+#define leftRotate47_64(a) (leftRotate_64((a), 47))
+#define leftRotate48_64(a) (leftRotate_64((a), 48))
+#define leftRotate49_64(a) (leftRotate_64((a), 49))
+#define leftRotate50_64(a) (leftRotate_64((a), 50))
+#define leftRotate51_64(a) (leftRotate_64((a), 51))
+#define leftRotate52_64(a) (leftRotate_64((a), 52))
+#define leftRotate53_64(a) (leftRotate_64((a), 53))
+#define leftRotate54_64(a) (leftRotate_64((a), 54))
+#define leftRotate55_64(a) (leftRotate_64((a), 55))
+#define leftRotate56_64(a) (leftRotate_64((a), 56))
+#define leftRotate57_64(a) (leftRotate_64((a), 57))
+#define leftRotate58_64(a) (leftRotate_64((a), 58))
+#define leftRotate59_64(a) (leftRotate_64((a), 59))
+#define leftRotate60_64(a) (leftRotate_64((a), 60))
+#define leftRotate61_64(a) (leftRotate_64((a), 61))
+#define leftRotate62_64(a) (leftRotate_64((a), 62))
+#define leftRotate63_64(a) (leftRotate_64((a), 63))
+
+// Right rotate by a specific number of bits.
+#define rightRotate1_64(a)  (rightRotate_64((a), 1))
+#define rightRotate2_64(a)  (rightRotate_64((a), 2))
+#define rightRotate3_64(a)  (rightRotate_64((a), 3))
+#define rightRotate4_64(a)  (rightRotate_64((a), 4))
+#define rightRotate5_64(a)  (rightRotate_64((a), 5))
+#define rightRotate6_64(a)  (rightRotate_64((a), 6))
+#define rightRotate7_64(a)  (rightRotate_64((a), 7))
+#define rightRotate8_64(a)  (rightRotate_64((a), 8))
+#define rightRotate9_64(a)  (rightRotate_64((a), 9))
+#define rightRotate10_64(a) (rightRotate_64((a), 10))
+#define rightRotate11_64(a) (rightRotate_64((a), 11))
+#define rightRotate12_64(a) (rightRotate_64((a), 12))
+#define rightRotate13_64(a) (rightRotate_64((a), 13))
+#define rightRotate14_64(a) (rightRotate_64((a), 14))
+#define rightRotate15_64(a) (rightRotate_64((a), 15))
+#define rightRotate16_64(a) (rightRotate_64((a), 16))
+#define rightRotate17_64(a) (rightRotate_64((a), 17))
+#define rightRotate18_64(a) (rightRotate_64((a), 18))
+#define rightRotate19_64(a) (rightRotate_64((a), 19))
+#define rightRotate20_64(a) (rightRotate_64((a), 20))
+#define rightRotate21_64(a) (rightRotate_64((a), 21))
+#define rightRotate22_64(a) (rightRotate_64((a), 22))
+#define rightRotate23_64(a) (rightRotate_64((a), 23))
+#define rightRotate24_64(a) (rightRotate_64((a), 24))
+#define rightRotate25_64(a) (rightRotate_64((a), 25))
+#define rightRotate26_64(a) (rightRotate_64((a), 26))
+#define rightRotate27_64(a) (rightRotate_64((a), 27))
+#define rightRotate28_64(a) (rightRotate_64((a), 28))
+#define rightRotate29_64(a) (rightRotate_64((a), 29))
+#define rightRotate30_64(a) (rightRotate_64((a), 30))
+#define rightRotate31_64(a) (rightRotate_64((a), 31))
+#define rightRotate32_64(a) (rightRotate_64((a), 32))
+#define rightRotate33_64(a) (rightRotate_64((a), 33))
+#define rightRotate34_64(a) (rightRotate_64((a), 34))
+#define rightRotate35_64(a) (rightRotate_64((a), 35))
+#define rightRotate36_64(a) (rightRotate_64((a), 36))
+#define rightRotate37_64(a) (rightRotate_64((a), 37))
+#define rightRotate38_64(a) (rightRotate_64((a), 38))
+#define rightRotate39_64(a) (rightRotate_64((a), 39))
+#define rightRotate40_64(a) (rightRotate_64((a), 40))
+#define rightRotate41_64(a) (rightRotate_64((a), 41))
+#define rightRotate42_64(a) (rightRotate_64((a), 42))
+#define rightRotate43_64(a) (rightRotate_64((a), 43))
+#define rightRotate44_64(a) (rightRotate_64((a), 44))
+#define rightRotate45_64(a) (rightRotate_64((a), 45))
+#define rightRotate46_64(a) (rightRotate_64((a), 46))
+#define rightRotate47_64(a) (rightRotate_64((a), 47))
+#define rightRotate48_64(a) (rightRotate_64((a), 48))
+#define rightRotate49_64(a) (rightRotate_64((a), 49))
+#define rightRotate50_64(a) (rightRotate_64((a), 50))
+#define rightRotate51_64(a) (rightRotate_64((a), 51))
+#define rightRotate52_64(a) (rightRotate_64((a), 52))
+#define rightRotate53_64(a) (rightRotate_64((a), 53))
+#define rightRotate54_64(a) (rightRotate_64((a), 54))
+#define rightRotate55_64(a) (rightRotate_64((a), 55))
+#define rightRotate56_64(a) (rightRotate_64((a), 56))
+#define rightRotate57_64(a) (rightRotate_64((a), 57))
+#define rightRotate58_64(a) (rightRotate_64((a), 58))
+#define rightRotate59_64(a) (rightRotate_64((a), 59))
+#define rightRotate60_64(a) (rightRotate_64((a), 60))
+#define rightRotate61_64(a) (rightRotate_64((a), 61))
+#define rightRotate62_64(a) (rightRotate_64((a), 62))
+#define rightRotate63_64(a) (rightRotate_64((a), 63))
+
+#endif // !CRYPTO_ROTATE64_COMPOSED
+
+#endif

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -27,11 +27,15 @@ platform = espressif8266
 board = d1_mini_pro
 board_build.ldscript = eagle.flash.4m1m.ld
 lib_deps = bblanchon/ArduinoJson@6.18.4
+build_flags = -D USE_BUILTIN_LED
 
 [env:esp8266_debug]
 extends = env:esp8266
 ; build_type = debug
-build_flags = -D DEBUG
+build_flags =
+  -D DEBUG
+  -D USE_BUILTIN_LED
+  ; -D DEBUG_ESP_PORT=Serial -D DEBUG_ESP_OTA -D DEBUG_ESP_UPDATER -D DEBUG_ESP_HTTP_UPDATE
 lib_deps = bblanchon/ArduinoJson@6.18.4
 
 [env:esp32]

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -26,26 +26,22 @@ monitor_flags = --raw
 platform = espressif8266
 board = d1_mini_pro
 board_build.ldscript = eagle.flash.4m1m.ld
-lib_deps = 
-	bblanchon/ArduinoJson@6.18.4
+lib_deps = bblanchon/ArduinoJson@6.18.4
 
 [env:esp8266_debug]
 extends = env:esp8266
 build_type = debug
 build_flags = -D DEBUG
-lib_deps = 
-	bblanchon/ArduinoJson@6.18.4
+lib_deps = bblanchon/ArduinoJson@6.18.4
 
 [env:esp32]
 platform = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
 platform_packages = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git
 board = esp32dev
-lib_deps = 
-	bblanchon/ArduinoJson@6.18.4
+lib_deps = bblanchon/ArduinoJson@6.18.4
 
 [env:esp32_debug]
 extends = env:esp32
 build_type = debug
 build_flags = -D DEBUG
-lib_deps = 
-	bblanchon/ArduinoJson@6.18.4
+lib_deps = bblanchon/ArduinoJson@6.18.4

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -30,7 +30,7 @@ lib_deps = bblanchon/ArduinoJson@6.18.4
 
 [env:esp8266_debug]
 extends = env:esp8266
-build_type = debug
+; build_type = debug
 build_flags = -D DEBUG
 lib_deps = bblanchon/ArduinoJson@6.18.4
 

--- a/firmware/src/crypto.cpp
+++ b/firmware/src/crypto.cpp
@@ -1,19 +1,21 @@
 #include "firmware.h"
-
-#ifdef ESP32
-#include "mbedtls/md.h"
-#else
-#include "Crypto.h"
-#endif
+#include "ChaChaPoly.h"
+#include "SHA256.h"
 
 String _hmacKey = "";
+uint8_t* _symKey;
 
 void loadKey() {
+    // The HMAC key is the raw HMAC file contents.
     _hmacKey = ReadFile(FILE_MESH_KEY);
 
     if (_hmacKey == "") {
         LOGF("crypto", "mesh key is not set");
     }
+
+    // Derive the symmetric encryption key from the raw HMAC one since separating cryptographic keys is a good thing to do.
+    String symData = "chacha-symmetric-key";
+    _symKey = hmac((const uint8_t*)symData.c_str(), symData.length());
 }
 
 String arrayToString(const uint8_t* raw, size_t length) {
@@ -30,7 +32,6 @@ String arrayToString(const uint8_t* raw, size_t length) {
     return result;
 }
 
-#ifdef ESP32
 uint8_t* hmac(const uint8_t* data, size_t dataLength) {
     if (_hmacKey == "") { loadKey(); }
 
@@ -39,51 +40,13 @@ uint8_t* hmac(const uint8_t* data, size_t dataLength) {
         LOGF("crypto", "unable to allocate memory");
     }
 
-    mbedtls_md_context_t ctx;
-    mbedtls_md_type_t md_type = MBEDTLS_MD_SHA256;
-
-    // Initialize the mbed TLS context and set it up for HMAC mode.
-    mbedtls_md_init(&ctx);
-
-    if (mbedtls_md_setup(&ctx, mbedtls_md_info_from_type(md_type), 1) != 0) {
-        LOGF("crypto", "setup failed");
-    }
-
-    // Setup the HMAC key.
-    if (mbedtls_md_hmac_starts(&ctx, (const unsigned char*)_hmacKey.c_str(), _hmacKey.length()) != 0) {
-        LOGF("crypto", "key write failed");
-    }
-
-    // Write the data to the started HMAC.
-    if (mbedtls_md_hmac_update(&ctx, data, dataLength) != 0) {
-        LOGF("crypto", "payload write failed");
-    }
-
-    // Finish and free the HMAC.
-    if (mbedtls_md_hmac_finish(&ctx, (uint8_t*)result) != 0) {
-        LOGF("crypto", "finalization failed");
-    }
-
-    mbedtls_md_free(&ctx);
+    SHA256* hmac = new SHA256();
+    hmac->resetHMAC(_hmacKey.c_str(), _hmacKey.length());
+    hmac->update(data, dataLength);
+    hmac->finalizeHMAC(_hmacKey.c_str(), _hmacKey.length(), result, 32);
 
     return (uint8_t*)result;
 }
-#else
-uint8_t* hmac(const uint8_t* data, const size_t dataLength) {
-    using namespace experimental::crypto;
-
-    if (_hmacKey == "") { loadKey(); }
-
-    void* result = calloc(32, sizeof(uint8_t));
-    if (result == NULL) {
-        LOGF("crypto", "unable to allocate memory");
-    }
-
-    SHA256::hmac(data, dataLength, _hmacKey.c_str(), _hmacKey.length(), result, 32);
-
-    return (uint8_t*)result;
-}
-#endif
 
 bool hmacCompare(const uint8_t* lhs, const uint8_t* rhs) {
     int result = 0;
@@ -92,4 +55,34 @@ bool hmacCompare(const uint8_t* lhs, const uint8_t* rhs) {
     }
 
     return result == 0;
+}
+
+bool decrypt(const char* cipher, const size_t cipherLength, const char* nonce, const char* tag, char* output) {
+    if (_hmacKey == "") { loadKey(); }
+
+    ChaChaPoly* chacha = new ChaChaPoly();
+
+    LOGD("crypto", "setting key to " + arrayToString(_symKey, 32));
+    if (!chacha->setKey(_symKey, 32)) {
+        LOGF("crypto", "symmetric key setup failed");
+    }
+
+    LOGD("crypto", "setting \"iv\" to " + arrayToString((const uint8_t*)nonce, 12));
+    if (!chacha->setIV((const uint8_t*)nonce, 12)) {
+        LOGF("crypto", "symmetric nonce setup failed");
+    }
+
+    LOGD("crypto", "decrypting ciphertext " + arrayToString((const uint8_t*)cipher, cipherLength));
+    chacha->decrypt((uint8_t*)output, (const uint8_t*)cipher, cipherLength);
+
+    LOGD("crypto", "tag is " + arrayToString((const uint8_t*)tag, 16));
+    bool okay = chacha->checkTag(tag, 16);
+    if (!okay) {
+        LOGW("crypto", "message authentication failed");
+    }
+
+    chacha->clear();
+    delete chacha;
+
+    return okay;
 }

--- a/firmware/src/crypto.cpp
+++ b/firmware/src/crypto.cpp
@@ -62,23 +62,26 @@ bool decrypt(const char* cipher, const size_t cipherLength, const char* nonce, c
 
     ChaChaPoly* chacha = new ChaChaPoly();
 
-    LOGD("crypto", "setting key to " + arrayToString(_symKey, 32));
     if (!chacha->setKey(_symKey, 32)) {
         LOGF("crypto", "symmetric key setup failed");
     }
 
-    LOGD("crypto", "setting \"iv\" to " + arrayToString((const uint8_t*)nonce, 12));
+    // LOGD("crypto", "setting \"iv\" to " + arrayToString((const uint8_t*)nonce, 12));
     if (!chacha->setIV((const uint8_t*)nonce, 12)) {
         LOGF("crypto", "symmetric nonce setup failed");
     }
 
-    LOGD("crypto", "decrypting ciphertext " + arrayToString((const uint8_t*)cipher, cipherLength));
+    // LOGD("crypto", "decrypting ciphertext " + arrayToString((const uint8_t*)cipher, cipherLength));
     chacha->decrypt((uint8_t*)output, (const uint8_t*)cipher, cipherLength);
 
-    LOGD("crypto", "tag is " + arrayToString((const uint8_t*)tag, 16));
+    // LOGD("crypto", "tag is " + arrayToString((const uint8_t*)tag, 16));
     bool okay = chacha->checkTag(tag, 16);
     if (!okay) {
         LOGW("crypto", "message authentication failed");
+
+        // Zeroize the output if the tag is wrong because ciphertext that fails authentication should never ever be released
+        // to callers ever but the library does so anyway.
+        memzero(output, cipherLength);
     }
 
     chacha->clear();

--- a/firmware/src/firmware.cpp
+++ b/firmware/src/firmware.cpp
@@ -25,7 +25,7 @@ void setup() {
 
     WiFi.persistent(false);
     WiFi.mode(WIFI_AP_STA);
-    Serial << "Mesh MAC address: " << WiFi.softAPmacAddress() << endl;
+    Serial << "Mesh MAC address: " << getIdentifier(true) << endl;
 
     // Check if the system has been configured
     bool configured = false;

--- a/firmware/src/firmware.cpp
+++ b/firmware/src/firmware.cpp
@@ -266,6 +266,11 @@ void processCommand(String command, bool secure) {
         secure = true;
     }
 
+    // Ignore MAC addresses that are prefixed to the JSON.
+    if (command.indexOf("dst-") == 0) {
+        command = command.substring(16);
+    }
+
     // Try to deserialize the input as JSON
     LOGD("cmnd", "deserializing '" + command + "'");
     DynamicJsonDocument data(1024);

--- a/firmware/src/firmware.cpp
+++ b/firmware/src/firmware.cpp
@@ -163,8 +163,6 @@ void loop() {
     // Note that delay() *cannot* be used here (or anywhere else in the loop function) because if a delay is active
     //    when an ESP-NOW message arrives, the message won't be processed by the system.
     if (millis() - lastPublish >= 60 * 1000) {
-        String strReading;
-
         StaticJsonDocument<100> mesh;
         meshStatistics stats = getStatistics();
 
@@ -173,10 +171,7 @@ void loop() {
         mesh["DL"] = stats.droppedLength;
         mesh["DA"] = stats.droppedAuth;
         mesh["AC"] = stats.accepted;
-        serializeJson(mesh, strReading);
-        publish(strReading, "mesh");
-        
-        strReading = "";
+        publish(&mesh, "mesh");
 
         lastPublish = millis();
 
@@ -190,10 +185,7 @@ void loop() {
         json["Error"] = reading.error;
         json["Temperature"] = reading.temperature;
         json["Humidity"] = reading.humidity;
-
-        serializeJson(json, strReading);
-
-        publish(strReading);
+        publish(&json, "data");
     }
 }
 

--- a/firmware/src/firmware.cpp
+++ b/firmware/src/firmware.cpp
@@ -145,7 +145,7 @@ void loop() {
     // Note that delay() *cannot* be used here (or anywhere else in the loop function) because if a delay is active
     //    when an ESP-NOW message arrives, the message won't be processed by the system.
     if (millis() - lastPublish >= 60 * 1000) {
-        StaticJsonDocument<100> mesh;
+        DynamicJsonDocument mesh(100);;
         meshStatistics stats = getStatistics();
 
         mesh["SE"] = stats.sent;
@@ -153,7 +153,7 @@ void loop() {
         mesh["DL"] = stats.droppedLength;
         mesh["DA"] = stats.droppedAuth;
         mesh["AC"] = stats.accepted;
-        publish(&mesh, "mesh");
+        publish(mesh, "mesh");
 
         lastPublish = millis();
 
@@ -163,11 +163,11 @@ void loop() {
 
         sensorData reading = getSensorData();
 
-        StaticJsonDocument<100> json;
+        DynamicJsonDocument json(100);
         json["Error"] = reading.error;
         json["Temperature"] = reading.temperature;
         json["Humidity"] = reading.humidity;
-        publish(&json, "data");
+        publish(json, "data");
     }
 }
 
@@ -220,7 +220,7 @@ void processCommand(String command, bool secure) {
 
     // Try to deserialize the input as JSON
     LOGD("cmnd", "deserializing '" + command + "'");
-    DynamicJsonDocument data(3 * 1024);
+    DynamicJsonDocument data(1024);
     DeserializationError error = deserializeJson(data, command);
 
     // Log success or failure

--- a/firmware/src/firmware.cpp
+++ b/firmware/src/firmware.cpp
@@ -399,8 +399,6 @@ void processCommand(String command, bool secure) {
 
             startUpdate(ssid, psk, url, length, checksum);
 
-            LOGD("ota", "returned from startUpdate");
-            // TODO: also update success based on message
             updateResult["Message"] = getUpdateMessage();
 
             if (isController) {
@@ -410,7 +408,10 @@ void processCommand(String command, bool secure) {
             safeDelay(500);
 
             publish(updateResult, "ota");
-            return;
+
+            safeDelay(500);
+
+            LOGF("ota", "restarting to recover from failed update");
         }
 
         else {

--- a/firmware/src/logger.cpp
+++ b/firmware/src/logger.cpp
@@ -1,6 +1,6 @@
 #include <logger.h>
 
-void logInternal(String level, String tag, String message) {
+void logAdvanced(String level, String tag, String message) {
     String color = "";
     String colorReset = "";
 
@@ -8,7 +8,11 @@ void logInternal(String level, String tag, String message) {
     color = "\033[1;";
     colorReset = "\033[0m";
 
-    if (level == "W") {
+    if (level == "I") {
+        color += "36m";     // blue
+    }
+
+    else if (level == "W") {
         color += "33m";     // yellow
     }
     
@@ -26,19 +30,16 @@ void logInternal(String level, String tag, String message) {
     Serial << color << level << tag << ": " << message << colorReset << endl;
 }
 
-void LOGD(String tag, String message) {
-    #ifndef DEBUG
-    return;
-    #endif
-
-    logInternal("D", tag, message);
+void LOGI(String tag, String message) {
+    logAdvanced("I", tag, message);
 }
 
 void LOGW(String tag, String message) {
-    logInternal("W", tag, message);
+    logAdvanced("W", tag, message);
 }
 
 void LOGF(String tag, String message) {
-    logInternal("F", tag, message);
+    logAdvanced("F", tag, message);
     ESP.restart();
+    while(1) { yield(); }
 }

--- a/firmware/src/mesh.cpp
+++ b/firmware/src/mesh.cpp
@@ -372,8 +372,8 @@ void meshReceiveCallbackHandler(const uint8_t* mac, const uint8_t* buf, int leng
                 LOGD("mesh", "handling unencrypted payload");
             }
 
-            LOGD("mesh", "handling command '" + payload + "'");
-            processCommand(payload);
+            LOGD("mesh", "queuing command '" + payload + "'");
+            queueCommand(payload);
         }
 
     } else {

--- a/firmware/src/mesh.cpp
+++ b/firmware/src/mesh.cpp
@@ -191,7 +191,7 @@ bool publishMesh(String message, String topic) {
 
     float l = payload.length();
     uint32_t correlation = secureRandom();
-    uint8_t total = ceil(l / 244.0);        // 244 bytes is the maximum payload (after the header is added).
+    uint8_t total = ceil(l / 212.0);        // 212 bytes is the maximum payload (after the header + HMAC is added).
 
     LOGD("mesh", "sending len:" + String(payload.length()) + ", cor:" + String(correlation, HEX) + ", tot:" + String(total));
     LOGD("mesh", "payload is '" + payload + "'");
@@ -360,7 +360,17 @@ void meshReceiveCallbackHandler(const uint8_t* mac, const uint8_t* buf, int leng
 
         // If this is a directed or broadcast command, handle it.
         if (isDirect || isBroadcast) {
+            // Strip off the mesh protocol header.
             payload = payload.substring(6, payload.length());
+
+            // If this is an encrypted payload, strip off the destination MAC address as well.
+            if (payload.charAt(0) != '{') {
+                LOGD("mesh", "handling encrypted payload");
+                payload = payload.substring(4+12, payload.length());
+
+            } else {
+                LOGD("mesh", "handling unencrypted payload");
+            }
 
             LOGD("mesh", "handling command '" + payload + "'");
             processCommand(payload);

--- a/firmware/src/mqtt.cpp
+++ b/firmware/src/mqtt.cpp
@@ -92,6 +92,12 @@ bool publish(String data, String teleTopic) {
     return publishMesh(data, topic);
 }
 
+bool publish(JsonDocument* doc, String topic) {
+    String json;
+    serializeJson(*doc, json);
+    return publish(json, topic);
+}
+
 String getClientId() {
     return clientId;
 }

--- a/firmware/src/mqtt.cpp
+++ b/firmware/src/mqtt.cpp
@@ -96,9 +96,9 @@ bool publish(String data, String teleTopic) {
     return publishMesh(data, topic);
 }
 
-bool publish(JsonDocument* doc, String topic) {
+bool publish(const JsonDocument& doc, const String topic) {
     String json;
-    serializeJson(*doc, json);
+    serializeJson(doc, json);
     return publish(json, topic);
 }
 

--- a/firmware/src/mqtt.cpp
+++ b/firmware/src/mqtt.cpp
@@ -6,9 +6,7 @@ String clientId, baseTopic;
 bool everConnected = false;
 
 void setupTopics() {
-    clientId = WiFi.softAPmacAddress();
-    clientId.replace(":", "");
-
+    clientId = getIdentifier();
 	baseTopic = "garden/module/" + clientId;
 }
 

--- a/firmware/src/mqtt.cpp
+++ b/firmware/src/mqtt.cpp
@@ -12,7 +12,7 @@ void setupTopics() {
 	baseTopic = "garden/module/" + clientId;
 }
 
-void connectToBroker(String host, String user, String pass) {
+void connectToBroker() {
     if (mqtt.connected()) {
         return;
     }
@@ -22,6 +22,10 @@ void connectToBroker(String host, String user, String pass) {
     }
 
     setupTopics();
+
+    String host = ReadFile(FILE_MQTT_HOST);
+    String user = ReadFile(FILE_MQTT_USER);
+    String pass = ReadFile(FILE_MQTT_PASS);
 
     // Log the connection attempt and try to connect
     bool auth = user.length() > 0;

--- a/firmware/src/mqtt.cpp
+++ b/firmware/src/mqtt.cpp
@@ -61,8 +61,8 @@ void mqttReceiveCallback(const MQTT::Publish& pub) {
     processCommand(payload);
 }
 
-void processMqtt() {
-    if (!mqtt.connected()) {
+void processMqtt(bool rebootIfDisconnected) {
+    if (!mqtt.connected() && rebootIfDisconnected) {
         LOGF("mqtt", "process() called but not connected");
     }
 
@@ -95,6 +95,10 @@ bool publish(String data, String teleTopic) {
 }
 
 bool publish(const JsonDocument& doc, const String topic) {
+    if (doc.overflowed()) {
+        LOGW("mqtt", "detected JSON document overflow");
+    }
+
     String json;
     serializeJson(doc, json);
     return publish(json, topic);

--- a/firmware/src/networking.cpp
+++ b/firmware/src/networking.cpp
@@ -26,6 +26,30 @@ void stopAccessPoint() {
     WiFi.softAPdisconnect(false);
 }
 
+void connectToWifi() {
+    String wifiSsid = ReadFile(FILE_WIFI_SSID);
+    String wifiPass = ReadFile(FILE_WIFI_PASS);
+
+    if (wifiSsid == "") {
+        return;
+    }
+
+    // Attempt to connect to the provided Wi-Fi network
+    WiFi.begin(wifiSsid.c_str(), wifiPass.c_str());
+
+    Serial << "Connecting to Wi-Fi";
+    while (WiFi.status() != WL_CONNECTED)
+    {
+        Serial << ".";
+        processCommand(Serial.readStringUntil('\n'), true);
+    }
+    Serial << endl;
+
+    Serial << "IP address: " << WiFi.localIP() << endl;
+
+    connectToBroker();
+}
+
 void startNetworkScan() {
     if (WiFi.scanComplete() == -1) {
         LOGD("wifi", "Network scan already in progress");

--- a/firmware/src/networking.cpp
+++ b/firmware/src/networking.cpp
@@ -160,3 +160,24 @@ String getIdentifier(bool includeColons) {
 
     return clientId;
 }
+
+int getMeshChannel() {
+    int meshChannel;
+
+    String rawChannel = ReadFile(FILE_MESH_CHANNEL);
+    if (rawChannel.length() > 0) {
+        meshChannel = rawChannel.toInt();
+
+        if (meshChannel <= 0) {
+            LOGW("mesh", "invalid mesh channel specified, defaulting to 1");
+            meshChannel = 1;
+        } else {
+            LOGD("mesh", "using mesh channel " + String(meshChannel));
+        }
+    } else {
+        LOGD("mesh", "using default channel of 1");
+        meshChannel = 1;
+    }
+
+    return meshChannel;
+}

--- a/firmware/src/networking.cpp
+++ b/firmware/src/networking.cpp
@@ -122,6 +122,9 @@ void sendDiscoveryMessage(bool useMqtt) {
     #ifdef ESP8266
     info["RR"] = ESP.getResetReason();
     info["CV"] = ESP.getCoreVersion();
+    info["TY"] = "ESP8266";
+    #else
+    info["TY"] = "ESP32";
     #endif
 
     info["SV"] = ESP.getSdkVersion();

--- a/firmware/src/networking.cpp
+++ b/firmware/src/networking.cpp
@@ -112,7 +112,7 @@ void processNetworkScan() {
         net["RSSI"] = i.RSSI;
     }
 
-    publish(&doc, "networks");
+    publish(doc, "networks");
 }
 
 #warning pass a string vector with discovered sensors
@@ -146,5 +146,5 @@ void sendDiscoveryMessage(bool useMqtt) {
     sensors.add("temperature");
     sensors.add("humidity");
 
-    publish(&info, "discovery");
+    publish(info, "discovery");
 }

--- a/firmware/src/networking.cpp
+++ b/firmware/src/networking.cpp
@@ -11,8 +11,7 @@ void startAccessPoint(int channel) {
     // Since the PSK is randomized every time it is started, this would wear out the flash very quickly.
     WiFi.persistent(false);
 
-    String apSsid = "m-" + WiFi.softAPmacAddress();
-    apSsid.replace(":", "");
+    String apSsid = "m-" + getIdentifier();
     apSsid.toLowerCase();
 
     String apPass = secureRandomNonce();
@@ -147,4 +146,14 @@ void sendDiscoveryMessage(bool useMqtt) {
     sensors.add("humidity");
 
     publish(info, "discovery");
+}
+
+String getIdentifier(bool includeColons) {
+    String clientId = WiFi.softAPmacAddress();
+
+    if (!includeColons) {
+        clientId.replace(":", "");
+    }
+
+    return clientId;
 }

--- a/firmware/src/networking.cpp
+++ b/firmware/src/networking.cpp
@@ -88,10 +88,7 @@ void processNetworkScan() {
         net["RSSI"] = i.RSSI;
     }
 
-    String serialized;
-    serializeJson(doc, serialized);
-
-    publish(serialized, "networks");
+    publish(&doc, "networks");
 }
 
 #warning pass a string vector with discovered sensors
@@ -125,8 +122,5 @@ void sendDiscoveryMessage(bool useMqtt) {
     sensors.add("temperature");
     sensors.add("humidity");
 
-    String discovery;
-    serializeJson(info, discovery);
-
-    publish(discovery, "discovery");
+    publish(&info, "discovery");
 }

--- a/firmware/src/ota.cpp
+++ b/firmware/src/ota.cpp
@@ -128,6 +128,9 @@ void startUpdate(String wifi, String psk, String url, size_t length, String chec
         goto fail;
     }
 
+    // The ID of the system is included so the server can monitor when a node starts downloading firmware.
+    http.addHeader("System-ID", getIdentifier());
+
     // Make the request and make sure that the response is 200 OK.
     httpCode = http.GET();
     LOGD("ota", "download response code is " + String(httpCode));

--- a/firmware/src/ota.cpp
+++ b/firmware/src/ota.cpp
@@ -1,0 +1,163 @@
+#include "firmware.h"
+
+#ifdef ESP32
+#include <Update.h>         // this is absolutely headass
+#include <HTTPClient.h>
+#else
+#include <Updater.h>        // FFS
+#include <ESP8266HTTPClient.h>
+#endif
+
+#include <WiFiClient.h>
+
+String updateResult = "Unknown failure";
+
+String getUpdateMessage() {
+    LOGD("ota", "result from update is " + updateResult);
+
+    // Only return this result once.
+    // TODO: move to a dedicated clearMessage() function.
+    String r = updateResult;
+    updateResult = "";
+
+    return r;
+}
+
+void onUpdateProgress(size_t lhs, size_t rhs) {
+    float percent = (lhs * 100) / rhs;
+    LOGD("ota", "update progress: " + String(percent) + "%");
+}
+
+void startUpdate(String wifi, String psk, String url, size_t length, String hash) {
+    LOGD("ota", "starting OTA update from " + url + " through " + wifi + ". current connection is " + WiFi.SSID());
+    LOGD("ota", "firmware is " + String(length) + " and has hash " + hash);
+
+    bool isController = FileExists(FILE_MESH_CONTROLLER);
+    HTTPClient http;
+    WiFiClient client;
+    int httpCode;
+    size_t written;
+
+    bool connect = false;
+    if (wifi == "") {
+        // If no network is specified, only proceed if we're already connected.
+        if (WiFi.SSID() == "") {
+            LOGW("ota", "no current connection & none provided");
+            updateResult = "not connected to wifi network and none was specified";
+            return;
+        } else {
+            // Assume that this network will work.
+            LOGD("ota", "no connection specified but connected, assuming this is okay");
+            connect = false;
+        }
+
+    } else {
+        // A network was specified. If we're already connected to it, great! If not, connect to it.
+        if (WiFi.SSID() != wifi) {
+            // Current connection is wrong, reconnect.
+            LOGD("ota", "connection specified and connected to different network, changing networks");
+            connect = true;
+        } else {
+            // Already connected, don't do anything.
+            LOGD("ota", "connection specified and already connected to it");
+            connect = false;
+        }
+    }
+
+    if (connect) {
+        if (isController) {
+            // TODO: pause MQTT watchdog until OTA has a result & we're reconnected to the hardcoded network
+            WiFi.disconnect();
+        }
+
+        // Connect to the new network.
+        LOGD("ota", "connecting to " + wifi);
+        WiFi.disconnect();
+        LOGD("ota", "beginning new connection");
+        WiFi.begin(wifi.c_str(), psk.c_str());
+        LOGD("ota", "connecting");
+
+        // Only try to connect to the network for 15s to prevent
+        unsigned long start = millis();
+        while (WiFi.status() != WL_CONNECTED && millis() - start <= 15 * 1000) {
+            Serial << ".";
+            yield();
+        }
+        Serial << endl;
+
+        if (WiFi.status() != WL_CONNECTED) {
+            // If the connection attempt failed, reconnect to the main network (connection is a no-op if not controller).
+            // TODO: does this fuck with the mesh?
+            updateResult = "Failed to connect to Wi-Fi";
+            goto fail;
+        }
+    } else {
+        LOGD("ota", "not changing wifi connections");
+    }
+
+    // Okay, we're connected to a network with access to the update server.
+    // Perform initial internal setup and get ready to download the file.
+    LOGD("ota", "setting update hash to " + hash + " and expected length to " + String(length));
+
+    if (!Update.begin(length)) {
+        updateResult = "not enough space to store update";
+        goto fail;
+    }
+
+    if (!Update.setMD5(hash.c_str())) {
+        updateResult = "failed to set checksum";
+        goto fail;
+    }
+
+    Update.onProgress(onUpdateProgress);
+
+    // Specifying the protocol is optional to save space in the JSON.
+    if (!url.startsWith("http://")) {
+        url = "http://" + url;
+    }
+
+    LOGD("ota", "starting download from " + url);
+
+    // Ensure that we don't hang forever trying to get the new firmware.
+    #ifdef ESP32
+    http.setConnectTimeout(10000);
+    #endif
+
+    http.setRedirectLimit(5);
+    http.setTimeout(10000);
+
+    if (!http.begin(client, url)) {
+        LOGD("ota", "unable to begin with specified url");
+        updateResult = "failed to begin HTTP connection";
+        goto fail;
+    }
+
+    // Make the request and make sure that the response is 200 OK.
+    httpCode = http.GET();
+    LOGD("ota", "download response code is " + String(httpCode));
+
+    if (httpCode != HTTP_CODE_OK) {
+        updateResult = "HTTP GET request failed with code " + String(httpCode);
+        goto fail;
+    }
+
+    written = Update.writeStream(http.getStream());
+    if (written != length) {
+        updateResult = "bytes written does not equal firmware length";
+        LOGW("ota", "wrote " + String(written) + " but firmware is known to be " + String(length));
+        goto fail;
+    }
+
+    LOGD("ota", "wrote new firmware, verifying checksum");
+    if (!Update.end()) {
+        updateResult = "failed to verify checksum";
+        goto fail;
+    }
+
+    LOGD("ota", "wrote new firmware successfully");
+    ESP.restart();
+
+    fail:
+    connectToWifi();
+    return;
+}

--- a/firmware/src/ota.cpp
+++ b/firmware/src/ota.cpp
@@ -53,7 +53,6 @@ void startUpdate(String wifi, String psk, String url, size_t length, String chec
         } else {
             // We're connected to something, assume that it will work.
             LOGD("ota", "no connection specified but connected, assuming this is okay");
-            connect = false;
         }
 
     } else {
@@ -65,7 +64,6 @@ void startUpdate(String wifi, String psk, String url, size_t length, String chec
         } else {
             // Already connected, don't do anything.
             LOGD("ota", "connection specified and already connected to it");
-            connect = false;
         }
     }
 

--- a/firmware/src/ota.cpp
+++ b/firmware/src/ota.cpp
@@ -10,7 +10,7 @@
 
 #include <WiFiClient.h>
 
-String updateResult = "Unknown failure";
+String updateResult = "unknown failure";
 
 String getUpdateMessage() {
     LOGD("ota", "result from update is " + updateResult);
@@ -102,8 +102,7 @@ void startUpdate(String wifi, String psk, String url, size_t length, String chec
 
         if (WiFi.status() != WL_CONNECTED) {
             // If the connection attempt failed, reconnect to the main network (connection is a no-op if not controller).
-            // TODO: does this fuck with the mesh?
-            updateResult = "Failed to connect to Wi-Fi";
+            updateResult = "failed to connect to network " + wifi;
             goto fail;
         }
     } else {
@@ -165,6 +164,5 @@ void startUpdate(String wifi, String psk, String url, size_t length, String chec
     fail:
     LOGW("ota", "error: " + updateResult + " (" + String(Update.getError()) + ")");
 
-    #warning USE CORRECT MESH CHANNEL HERE
-    startAccessPoint(7);
+    startAccessPoint(getMeshChannel());
 }

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -17,6 +17,7 @@ export type GardenSystem = {
   Announcement: GardenSystemInfo;
   LastReading: Reading;
   Readings: Array<Reading>;
+  UpdateStatus: OTAStatus;
 };
 
 export type GardenSystemInfo = {
@@ -52,4 +53,13 @@ export type Reading = {
   Error: boolean;
   Temperature?: number;
   Humidity?: number;
+};
+
+export type OTAStatus = {
+  LoggedAt?: Date;
+  Success: boolean;
+  Message: string;
+
+  // Time (in seconds) since the previous message.
+  Delta?: string;
 };

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -34,6 +34,8 @@ export type GardenSystemInfo = {
 
   RestartReason: string;
 
+  // Chipset on this system. Either "ESP8266" or "ESP32".
+  Chipset: string;
   CoreVersion: string;
   SdkVersion: string;
 

--- a/frontend/src/views/SystemInfo.vue
+++ b/frontend/src/views/SystemInfo.vue
@@ -26,16 +26,15 @@
         <v-col lg cols="6">
           <h2>Update firmware</h2>
           <p>
-            Systems can only be updated over Wi-Fi. Specify the network name and
-            password of a network that this system should connect to in order to
-            download the new firmware. You must also specify the IP address and
-            port of the backend server on that network.
+            To update this system, specify a Wi-Fi network and password the
+            system can connect to with access to the backend server.
           </p>
 
           <p>
-            Systems that are downloading new firmware will disconnect from MQTT
-            and the mesh for up to two minutes. In the event of an error, the
-            system will restart itself without installing the new firmware.
+            Systems that are updating will not communicate with the backend
+            server or relay mesh messages for up to two minutes. In the event of
+            an error, the system will restart itself without installing the
+            update.
           </p>
 
           <v-form>
@@ -60,11 +59,47 @@
         </v-col>
       </v-row>
     </v-container>
+    <br />
+
     <v-expansion-panels>
       <v-expansion-panel>
-        <v-expansion-panel-header>Debug Info</v-expansion-panel-header>
+        <v-expansion-panel-header>
+          I want to update a system from a network without access to my backend
+          server
+        </v-expansion-panel-header>
         <v-expansion-panel-content>
-          <pre> {{ JSON.stringify(system, undefined, 2) }} </pre>
+          <span>
+            It is possible to update systems even if they are on a separate
+            network from the backend server. To download a firmware update,
+            systems make an HTTP GET request to either:
+          </span>
+
+          <ul>
+            <li>
+              <code>http://UPDATE_HOST/fw82</code> is the system is running on
+              an ESP8266, or
+            </li>
+            <li>
+              <code>http://UPDATE_HOST/fw32</code> is the system is running on
+              an ESP32
+            </li>
+          </ul>
+          <br />
+
+          <span>
+            Your HTTP server must:
+            <ol>
+              <li>
+                Allow unauthenticated HTTP access to <code>/fw82</code> and
+                <code>/fw32</code>
+              </li>
+              <li>Send a correct Content-Length header</li>
+            </ol>
+            <br />
+
+            If you have <code>python3</code> installed on your system, the
+            command <code>python3 -m http.server</code> works well.
+          </span>
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>
@@ -109,7 +144,13 @@ export default Vue.extend({
         mutation.payload.Identifier === this.id
       ) {
         this.system = mutation.payload;
-        this.update.loading = false;
+        /* TODO: fix infinite spinner by:
+         *   creating an update log on this screen that defaults to "sent update command"
+         *   the backend can use a new property called UpdateStatus that it updates when a system:
+         *     publishes a message to tele/whatever/ota
+         *     makes a request to /fwNN with a system ID header
+         *     restarts with a new firmware version
+         */
       }
     },
     startUpdate() {

--- a/frontend/src/views/SystemWizard.vue
+++ b/frontend/src/views/SystemWizard.vue
@@ -227,11 +227,6 @@
               label="Channel"
               hint="The channel that the mesh controller is listening on."
             />
-
-            <v-alert color="warning darken-1">
-              TODO: Both of these fields need to be autofilled by the server and
-              displayed as dropdowns.
-            </v-alert>
           </v-form>
 
           <v-btn
@@ -314,6 +309,7 @@ import WizardCard from "@/components/WizardCard.vue";
 import "esp-web-tools";
 
 import { Dictionary } from "vue-router/types/router";
+import api from "@/plugins/api";
 
 export default Vue.extend({
   name: "SystemWizard",
@@ -331,7 +327,8 @@ export default Vue.extend({
         mqttUser: window.localStorage.getItem("mqttUser") || "",
         mqttPass: window.localStorage.getItem("mqttPass") || "",
         meshController: window.localStorage.getItem("meshController") || "",
-        meshChannel: window.localStorage.getItem("meshChannel") || ""
+        meshChannel: window.localStorage.getItem("meshChannel") || "",
+        meshKey: ""
       } as Dictionary<string>,
 
       snackbar: {
@@ -340,6 +337,18 @@ export default Vue.extend({
         text: ""
       }
     };
+  },
+  async mounted() {
+    api("/mesh/info").
+    then((r) => {
+      return r.json();
+    })
+    .then((res) => {
+      const c = this.$data.config;
+      c.meshController = res["Controller"];
+      c.meshChannel = res["Channel"];
+      c.meshKey = res["Key"];
+    })
   },
   computed: {
     secure() {
@@ -421,6 +430,8 @@ export default Vue.extend({
 
           break;
       }
+
+      serialized.MeshKey = this.$data.config.meshKey;
 
       return JSON.stringify(serialized);
     },


### PR DESCRIPTION
This was an exercise in yak shaving over 10 days.

Firmware on both the ESP8266 and ESP32 can now be securely updated over the air (OTA).

Notes:
* Since the updater library in the Arduino core only supports MD5 (which is very very broken), update commands are required to be encrypted, thus providing confidentiality, integrity, and authenticity. This is handled transparently.
* Firmware binaries need to be placed at `data/firmware/esp{8266,32}/firmware.bin`